### PR TITLE
Updates to inpage #1

### DIFF
--- a/inpage/.eslintrc.cjs
+++ b/inpage/.eslintrc.cjs
@@ -89,5 +89,6 @@ module.exports = {
       },
     ],
     'no-use-before-define': 'off',
+    'no-redeclare': 'off',
   },
 };

--- a/inpage/.eslintrc.cjs
+++ b/inpage/.eslintrc.cjs
@@ -92,5 +92,6 @@ module.exports = {
     'no-redeclare': 'off',
     'brace-style': 'off',
     'no-restricted-syntax': 'off',
+    'operator-linebreak': 'off',
   },
 };

--- a/inpage/.eslintrc.cjs
+++ b/inpage/.eslintrc.cjs
@@ -90,5 +90,7 @@ module.exports = {
     ],
     'no-use-before-define': 'off',
     'no-redeclare': 'off',
+    'brace-style': 'off',
+    'no-restricted-syntax': 'off',
   },
 };

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -68,9 +68,10 @@ const App = () => {
               });
 
               // TODO: Better type information for EthereumApi
-              assert(typeof response === 'string');
+              assert(Array.isArray(response));
+              assert(typeof response[0] === 'string');
 
-              setAddress(response);
+              setAddress(response[0]);
             }}
           >
             Connect

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -17,6 +17,18 @@ const App = () => {
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
+      if (!address) {
+        const accounts = z.array(z.string()).parse(
+          await demo.ethereum.request({
+            method: 'eth_accounts',
+          }),
+        );
+
+        if (accounts.length > 0) {
+          setAddress(accounts[0]);
+        }
+      }
+
       if (address) {
         setBalance(await demo.provider.getBalance(address));
       }

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -75,15 +75,9 @@ const App = () => {
           style={{ display: 'inline-block' }}
           type="button"
           onPress={async () => {
-            // TODO: Better type information for EthereumApi
-            const response = z
-              .array(z.string())
-              .min(1)
-              .parse(
-                await demo.ethereum.request({
-                  method: 'eth_requestAccounts',
-                }),
-              );
+            const response = await demo.ethereum.request({
+              method: 'eth_requestAccounts',
+            });
 
             setAddress(response[0]);
           }}

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -6,6 +6,8 @@ import DemoContext from './DemoContext';
 import Heading from '../src/Heading';
 import assert from '../src/helpers/assert';
 
+const globalRecord = globalThis as Record<string, unknown>;
+
 const App = () => {
   const demo = DemoContext.use();
 
@@ -78,6 +80,15 @@ const App = () => {
           </Button>
         </div>
       )}
+      <Button
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onClick={async () => {
+          const signer = await demo.provider.getSigner();
+          globalRecord.signer = signer;
+        }}
+      >
+        window.signer
+      </Button>
     </>
   );
 };

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -63,8 +63,7 @@ const App = () => {
           <Button
             style={{ display: 'inline-block' }}
             type="button"
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            onClick={async () => {
+            onPress={async () => {
               // TODO: Better type information for EthereumApi
               const response = z
                 .array(z.string())
@@ -83,8 +82,8 @@ const App = () => {
         </div>
       )}
       <Button
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        onClick={async () => {
+        secondary
+        onPress={async () => {
           const signer = await demo.provider.getSigner();
           globalRecord.signer = signer;
         }}
@@ -92,8 +91,8 @@ const App = () => {
         window.signer
       </Button>
       <Button
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        onClick={async () => {
+        secondary
+        onPress={async () => {
           await demo.waxInPage.storage.clear();
           setAddress(undefined);
           setBalance(undefined);

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -71,27 +71,25 @@ const App = () => {
         </div>
       )}
       {address === undefined && (
-        <div>
-          <Button
-            style={{ display: 'inline-block' }}
-            type="button"
-            onPress={async () => {
-              // TODO: Better type information for EthereumApi
-              const response = z
-                .array(z.string())
-                .min(1)
-                .parse(
-                  await demo.ethereum.request({
-                    method: 'eth_requestAccounts',
-                  }),
-                );
+        <Button
+          style={{ display: 'inline-block' }}
+          type="button"
+          onPress={async () => {
+            // TODO: Better type information for EthereumApi
+            const response = z
+              .array(z.string())
+              .min(1)
+              .parse(
+                await demo.ethereum.request({
+                  method: 'eth_requestAccounts',
+                }),
+              );
 
-              setAddress(response[0]);
-            }}
-          >
-            Connect
-          </Button>
-        </div>
+            setAddress(response[0]);
+          }}
+        >
+          Connect
+        </Button>
       )}
       <Button
         secondary

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -91,6 +91,16 @@ const App = () => {
       >
         window.signer
       </Button>
+      <Button
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onClick={async () => {
+          await demo.waxInPage.storage.clear();
+          setAddress(undefined);
+          setBalance(undefined);
+        }}
+      >
+        Clear
+      </Button>
     </>
   );
 };

--- a/inpage/demo/App.tsx
+++ b/inpage/demo/App.tsx
@@ -1,10 +1,10 @@
+import z from 'zod';
 import { ethers } from 'ethers';
 import { useEffect, useState } from 'react';
 import './App.css';
 import Button from '../src/Button';
 import DemoContext from './DemoContext';
 import Heading from '../src/Heading';
-import assert from '../src/helpers/assert';
 
 const globalRecord = globalThis as Record<string, unknown>;
 
@@ -65,13 +65,15 @@ const App = () => {
             type="button"
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={async () => {
-              const response = await demo.ethereum.request({
-                method: 'eth_requestAccounts',
-              });
-
               // TODO: Better type information for EthereumApi
-              assert(Array.isArray(response));
-              assert(typeof response[0] === 'string');
+              const response = z
+                .array(z.string())
+                .min(1)
+                .parse(
+                  await demo.ethereum.request({
+                    method: 'eth_requestAccounts',
+                  }),
+                );
 
               setAddress(response[0]);
             }}

--- a/inpage/package.json
+++ b/inpage/package.json
@@ -17,6 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@s-libs/micro-dash": "^16.0.0",
     "@types/color": "^3.0.3",
     "color": "^4.2.3",
     "jss": "^10.10.0",

--- a/inpage/package.json
+++ b/inpage/package.json
@@ -22,7 +22,8 @@
     "jss": "^10.10.0",
     "jss-preset-default": "^10.10.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@types/node": "^20.4.2",

--- a/inpage/src/Button.tsx
+++ b/inpage/src/Button.tsx
@@ -44,6 +44,7 @@ const sheet = jss.createStyleSheet({
   },
   ButtonDisabled: {
     filter: 'brightness(50%)',
+    cursor: 'initial',
   },
 });
 

--- a/inpage/src/Button.tsx
+++ b/inpage/src/Button.tsx
@@ -1,6 +1,7 @@
 import jss from 'jss';
 import color from 'color';
-import { HTMLProps } from 'react';
+import React, { HTMLProps, useCallback, useState } from 'react';
+import assert from 'assert';
 import sheetsRegistry from './sheetsRegistry';
 import { bgColor, fgColor } from './styleConstants';
 import classes from './helpers/classes';
@@ -15,7 +16,8 @@ const sheet = jss.createStyleSheet({
     background: color(fgColor).darken(0.1).toString(),
     border: `1px solid ${color(fgColor).darken(0.1).toString()}`,
     color: bgColor,
-
+  },
+  ButtonStates: {
     '&:hover': {
       background: fgColor,
       border: `1px solid ${fgColor}`,
@@ -30,7 +32,8 @@ const sheet = jss.createStyleSheet({
     background: 'transparent',
     border: `1px solid ${fgColor}`,
     color: fgColor,
-
+  },
+  ButtonSecondaryStates: {
     '&:hover': {
       background: color(fgColor).alpha(0.05).toString(),
     },
@@ -39,6 +42,9 @@ const sheet = jss.createStyleSheet({
       background: color(fgColor).alpha(0.15).toString(),
     },
   },
+  ButtonDisabled: {
+    filter: 'brightness(50%)',
+  },
 });
 
 sheetsRegistry.add(sheet);
@@ -46,17 +52,65 @@ sheetsRegistry.add(sheet);
 const Button = ({
   children,
   secondary,
+  disabled,
+  onPress = () => undefined,
   ...props
-}: Omit<HTMLProps<HTMLDivElement>, 'className'> & { secondary?: boolean }) => (
-  <div
-    {...props}
-    {...classes(
-      sheet.classes.Button,
-      secondary && sheet.classes.ButtonSecondary,
-    )}
-  >
-    {children}
-  </div>
-);
+}: Omit<HTMLProps<HTMLDivElement>, 'className' | 'onClick'> & {
+  secondary?: boolean;
+  onPress?: (
+    e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
+  ) => unknown;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [_error, setError] = useState<unknown>();
+
+  const handlePress = useCallback(
+    (
+      e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
+    ) => {
+      if (disabled || loading) {
+        return;
+      }
+
+      (async () => {
+        try {
+          setLoading(true);
+          await onPress(e);
+          setError(undefined);
+        } catch (newError) {
+          // eslint-disable-next-line no-console
+          console.error(newError);
+          setError(newError);
+        }
+
+        setLoading(false);
+      })().catch(() => assert(false));
+    },
+    [disabled, loading, onPress],
+  );
+
+  const effectivelyDisabled = loading || disabled;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      {...props}
+      onClick={handlePress}
+      onKeyDown={handlePress}
+      {...classes(
+        sheet.classes.Button,
+        secondary && sheet.classes.ButtonSecondary,
+        !effectivelyDisabled &&
+          (secondary
+            ? sheet.classes.ButtonSecondaryStates
+            : sheet.classes.ButtonStates),
+        effectivelyDisabled && sheet.classes.ButtonDisabled,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default Button;

--- a/inpage/src/EthereumApi.ts
+++ b/inpage/src/EthereumApi.ts
@@ -6,6 +6,8 @@ export default class EthereumApi {
   #testAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
   #requestPermission: (message: string) => Promise<boolean>;
 
+  #connectedAccounts: string[] = [];
+
   constructor(requestPermission: (message: string) => Promise<boolean>) {
     this.#requestPermission = requestPermission;
   }
@@ -21,10 +23,18 @@ export default class EthereumApi {
       return await this.#requestAccounts();
     }
 
+    if (method === 'eth_accounts') {
+      return await this.#accounts();
+    }
+
     return await this.#networkRequest({ method, params });
   }
 
   async #requestAccounts() {
+    if (this.#connectedAccounts.length > 0) {
+      return structuredClone(this.#connectedAccounts);
+    }
+
     const granted = await this.#requestPermission(
       'Allow this page to see your account address?',
     );
@@ -36,7 +46,14 @@ export default class EthereumApi {
       });
     }
 
-    return [this.#testAddress];
+    this.#connectedAccounts = [this.#testAddress];
+
+    return await this.#accounts();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async #accounts() {
+    return structuredClone(this.#connectedAccounts);
   }
 
   async #networkRequest({

--- a/inpage/src/EthereumApi.ts
+++ b/inpage/src/EthereumApi.ts
@@ -5,6 +5,37 @@ import assert from './helpers/assert';
 import randomId from './helpers/randomId';
 import { WaxStorage } from './WaxStorage';
 
+const emptyParams = z.union([z.tuple([]), z.undefined()]);
+
+const schema = {
+  eth_requestAccounts: {
+    params: emptyParams,
+    output: z.array(z.string()).min(1),
+  },
+  eth_accounts: {
+    params: emptyParams,
+    output: z.array(z.string()),
+  },
+};
+
+type Schema = typeof schema;
+
+type RequestParams<M extends string> = M extends keyof Schema
+  ? undefined extends z.infer<Schema[M]['params']>
+    ? { params?: z.infer<Schema[M]['params']> }
+    : { params: z.infer<Schema[M]['params']> }
+  : { params?: unknown[] };
+
+type Response<M extends string> = M extends keyof Schema
+  ? z.infer<Schema[M]['output']>
+  : unknown;
+
+type SchemaHandlers = {
+  [M in keyof Schema]: (
+    ...params: Exclude<z.infer<Schema[M]['params']>, undefined>
+  ) => Promise<Response<M>>;
+};
+
 export default class EthereumApi {
   #storage: WaxStorage;
 
@@ -20,52 +51,68 @@ export default class EthereumApi {
     this.#storage = storage;
   }
 
-  async request({
+  async request<M extends string>({
     method,
-    params = [],
+    params,
+  }: {
+    method: M;
+  } & RequestParams<M>): Promise<Response<M>> {
+    if (!(method in schema)) {
+      return (await this.#requestImpl({ method, params })) as Response<M>;
+    }
+
+    const methodSchema = schema[method as keyof Schema];
+
+    const parsedParams = methodSchema.params.parse(params);
+    const response = await this.#requestImpl({ method, params: parsedParams });
+
+    const parsedResponse = methodSchema.output.parse(response);
+    return parsedResponse as Response<M>;
+  }
+
+  async #requestImpl({
+    method,
+    params,
   }: {
     method: string;
     params?: unknown[];
-  }) {
-    if (method === 'eth_requestAccounts') {
-      return await this.#requestAccounts();
-    }
-
-    if (method === 'eth_accounts') {
-      return await this.#accounts();
+  }): Promise<unknown> {
+    if (method in this.#customHandlers) {
+      // eslint-disable-next-line
+      return await (this.#customHandlers as any)[method](...(params ?? []));
     }
 
     return await this.#networkRequest({ method, params });
   }
 
-  async #requestAccounts() {
-    let connectedAccounts = await this.#storage.connectedAccounts.get();
+  #customHandlers: Partial<SchemaHandlers> = {
+    eth_requestAccounts: async () => {
+      let connectedAccounts = await this.#storage.connectedAccounts.get();
 
-    if (connectedAccounts.length > 0) {
+      if (connectedAccounts.length > 0) {
+        return connectedAccounts;
+      }
+
+      const granted = await this.#requestPermission(
+        'Allow this page to see your account address?',
+      );
+
+      if (!granted) {
+        throw new JsonRpcError({
+          code: 4001,
+          message: 'User rejected request',
+        });
+      }
+
+      connectedAccounts = [this.#testAddress];
+
+      await this.#storage.connectedAccounts.set(connectedAccounts);
+
       return connectedAccounts;
-    }
+    },
 
-    const granted = await this.#requestPermission(
-      'Allow this page to see your account address?',
-    );
-
-    if (!granted) {
-      throw new JsonRpcError({
-        code: 4001,
-        message: 'User rejected request',
-      });
-    }
-
-    connectedAccounts = [this.#testAddress];
-
-    await this.#storage.connectedAccounts.set(connectedAccounts);
-
-    return connectedAccounts;
-  }
-
-  async #accounts() {
-    return await this.#storage.connectedAccounts.get();
-  }
+    eth_accounts: async () => await this.#storage.connectedAccounts.get(),
+  };
 
   async #networkRequest({
     method,

--- a/inpage/src/EthereumApi.ts
+++ b/inpage/src/EthereumApi.ts
@@ -36,7 +36,7 @@ export default class EthereumApi {
       });
     }
 
-    return this.#testAddress;
+    return [this.#testAddress];
   }
 
   async #networkRequest({

--- a/inpage/src/JsonRpcError.ts
+++ b/inpage/src/JsonRpcError.ts
@@ -1,0 +1,28 @@
+import z from 'zod';
+
+class JsonRpcError extends Error {
+  code: number;
+  data: unknown;
+
+  constructor({ code, data, message }: RawJsonRpcError) {
+    super(message);
+
+    this.code = code;
+    this.data = data;
+  }
+
+  static parse(rawError: unknown) {
+    return new JsonRpcError(RawJsonRpcError.parse(rawError));
+  }
+}
+
+const RawJsonRpcError = z.object({
+  code: z.number().int(),
+  data: z.unknown(),
+  message: z.string(),
+});
+
+type RawJsonRpcError = z.infer<typeof RawJsonRpcError>;
+
+export default JsonRpcError;
+export { RawJsonRpcError };

--- a/inpage/src/PermissionPopup.tsx
+++ b/inpage/src/PermissionPopup.tsx
@@ -35,10 +35,10 @@ const PermissionPopup = ({
     <Heading>Permission Request</Heading>
     <div>{message}</div>
     <div className={sheet.classes.ButtonRow}>
-      <Button secondary onClick={() => respond(false)}>
+      <Button secondary onPress={() => respond(false)}>
         Deny
       </Button>
-      <Button onClick={() => respond(true)}>Approve</Button>
+      <Button onPress={() => respond(true)}>Approve</Button>
     </div>
   </div>
 );

--- a/inpage/src/WaxInPage.tsx
+++ b/inpage/src/WaxInPage.tsx
@@ -6,6 +6,7 @@ import assert from './helpers/assert';
 import popupUrl from './popupUrl';
 import PermissionPopup from './PermissionPopup';
 import sheetsRegistry from './sheetsRegistry';
+import makeLocalWaxStorage, { WaxStorage } from './WaxStorage';
 
 const defaultConfig = {
   requirePermission: true,
@@ -16,11 +17,17 @@ type Config = typeof defaultConfig;
 export default class WaxInPage {
   #config = defaultConfig;
 
-  private constructor(public ethereum: EthereumApi) {}
+  private constructor(
+    public ethereum: EthereumApi,
+    public storage: WaxStorage,
+  ) {}
 
   static create(): WaxInPage {
+    const storage = makeLocalWaxStorage();
+
     const wax: WaxInPage = new WaxInPage(
-      new EthereumApi((message) => wax.requestPermission(message)),
+      new EthereumApi((message) => wax.requestPermission(message), storage),
+      storage,
     );
 
     return wax;

--- a/inpage/src/WaxStorage.ts
+++ b/inpage/src/WaxStorage.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mapValues } from '@s-libs/micro-dash';
+import z from 'zod';
+
+const typeAndDefault = <T>(type: z.ZodType<T>, default_: T) => ({
+  type,
+  default_,
+});
+
+const schema = {
+  connectedAccounts: typeAndDefault(z.array(z.string()), []),
+};
+
+type Field<T> = {
+  get(): Promise<T>;
+  set(value: T): Promise<void>;
+  clear(): Promise<void>;
+};
+
+export type WaxStorage = {
+  [K in keyof typeof schema]: Field<z.infer<(typeof schema)[K]['type']>>;
+} & {
+  clear(): Promise<void>;
+};
+
+export default function makeLocalWaxStorage() {
+  const fields = mapValues(schema, ({ type, default_ }, key) => ({
+    async get() {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      const raw = localStorage.getItem(`wax-${key}`);
+
+      if (raw === null) {
+        return structuredClone(default_);
+      }
+
+      return type.parse(JSON.parse(raw));
+    },
+
+    async set(value: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      localStorage.setItem(`wax-${key}`, JSON.stringify(type.parse(value)));
+    },
+
+    async clear() {
+      localStorage.removeItem(`wax-${key}`);
+    },
+  }));
+
+  return {
+    ...fields,
+
+    async clear() {
+      for (const key of Object.keys(schema)) {
+        localStorage.removeItem(`wax-${key}`);
+      }
+    },
+  } as WaxStorage;
+}

--- a/inpage/yarn.lock
+++ b/inpage/yarn.lock
@@ -2729,3 +2729,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==

--- a/inpage/yarn.lock
+++ b/inpage/yarn.lock
@@ -223,6 +223,14 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@s-libs/micro-dash@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@s-libs/micro-dash/-/micro-dash-16.0.0.tgz#08af9c9bc91eee0b534642bcae73e6f5bbd64847"
+  integrity sha512-LNQi1zBIWOeBNzD7KqvhAusoYM2dloZF57ipV/hUk+5A7x7UpUkCm0mmtdxK32BdKv+1D8DKHmTQafnNA5l+Wg==
+  dependencies:
+    tslib "^2.3.0"
+    utility-types "^3.10.0"
+
 "@swc/core-darwin-arm64@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.69.tgz#e22032471244ec80c22bee8efc2100e456bb9488"
@@ -2547,7 +2555,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.0, tslib@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
   integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
@@ -2636,6 +2644,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+utility-types@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
 vite@^4.4.0:
   version "4.4.4"


### PR DESCRIPTION
Resolves #17.

- Make `eth_requestAccounts` return an array instead of a single address (see `eth_requestAccounts` in [EIP-1102](https://eips.ethereum.org/EIPS/eip-1102))
- Implement `eth_accounts`
  - Returns array of already-connected accounts (doesn't need the user's permission)
  - Enables ethers' `getSigner` method
- Use localstorage so you don't need to reconnect your address when you return/refresh
- Use the `eth_accounts` API in the demo to avoid needing to re-request accounts
- Add `disabled` state for `<Button/>` and apply it when an async callback is in progress