### PR TITLE
Inpage: Enable external networks

### DIFF
--- a/inpage/.eslintrc.cjs
+++ b/inpage/.eslintrc.cjs
@@ -56,6 +56,7 @@ module.exports = {
         devDependencies: [
           'demo/**/*.ts',
           'demo/**/*.tsx',
+          'scripts/**/*.ts',
           'vite.config.ts',
           'hardhat/**/*.ts',
         ],

--- a/inpage/.gitignore
+++ b/inpage/.gitignore
@@ -1,3 +1,5 @@
+demo/config.ts
+
 # Logs
 logs
 *.log

--- a/inpage/README.md
+++ b/inpage/README.md
@@ -33,9 +33,11 @@ yet.)
 Then:
 
 ```ts
-import WaxInPage from '@getwax/wax';
+import WaxInPage from '@getwax/inpage';
 
-const wax = new WaxInPage();
+const wax = new WaxInPage({
+  rpcUrl: '<your rpc url>', // eg for hardhat use http://127.0.0.1:8545
+});
 
 console.log(await wax.ethereum.request({
   method: 'eth_requestAccounts',
@@ -43,7 +45,9 @@ console.log(await wax.ethereum.request({
 
 // Alternatively...
 
-WaxInPage.global();
+WaxInPage.global({
+  rpcUrl: '<your rpc url>', // eg for hardhat use http://127.0.0.1:8545
+});
 
 console.log(await ethereum.request({
   method: 'eth_requestAccounts',

--- a/inpage/README.md
+++ b/inpage/README.md
@@ -63,9 +63,14 @@ yarn build
 
 Copy `waxInPage.iife.js` to your `public/ext` directory.
 
-Add this script to your html:
+Add these scripts to your html:
 
 ```html
+<script>
+window.waxInPageConfig = {
+  rpcUrl: '<your rpc url>', // eg for hardhat use http://127.0.0.1:8545
+};
+</script>
 <script src="/ext/waxInPage.iife.js"></script>
 ```
 

--- a/inpage/README.md
+++ b/inpage/README.md
@@ -16,6 +16,10 @@ yarn setup
 yarn dev
 ```
 
+The dev server will run a hardhat-based testnet for you by default. If you'd
+like to use an external network, configure your `rpcUrl` in `demo/config.ts` and
+the dev server will skip running a local node.
+
 ## Use the Library (as an Npm Module)
 
 ```sh

--- a/inpage/demo/ConfigType.ts
+++ b/inpage/demo/ConfigType.ts
@@ -1,6 +1,7 @@
 type ConfigType = {
   rpcUrl: string;
   pollingInterval?: number;
+  addFundsEthAmount?: string;
 };
 
 export default ConfigType;

--- a/inpage/demo/ConfigType.ts
+++ b/inpage/demo/ConfigType.ts
@@ -1,0 +1,6 @@
+type ConfigType = {
+  rpcUrl: string;
+  pollingInterval?: number;
+};
+
+export default ConfigType;

--- a/inpage/demo/LinksPage.tsx
+++ b/inpage/demo/LinksPage.tsx
@@ -1,8 +1,18 @@
 import './LinksPage.css';
+import { ethers } from 'ethers';
 import Button from '../src/Button';
 import usePath from './usePath';
 import DemoContext from './DemoContext';
 import runAsync from './helpers/runAsync';
+import config from './config';
+
+const addFundsDefault = (() => {
+  if (config.rpcUrl === 'http://127.0.0.1:8545') {
+    return '1.0';
+  }
+
+  return '0.002';
+})();
 
 const LinksPage = () => {
   const demo = DemoContext.use();
@@ -26,7 +36,9 @@ const LinksPage = () => {
           await (
             await admin.sendTransaction({
               to: address,
-              value: 10n ** 18n,
+              value: ethers.parseEther(
+                config.addFundsEthAmount ?? addFundsDefault,
+              ),
             })
           ).wait();
 

--- a/inpage/demo/config.template.ts
+++ b/inpage/demo/config.template.ts
@@ -1,0 +1,16 @@
+// config.template.ts is tracked in git
+// config.ts is not tracked in git
+//
+// This allows us to track the starting recommendations for the config without
+// getting mixed up with local preferences.
+//
+// If config.ts doesn't yet exist, it will be created as a copy of the template
+// during `yarn setup`.
+
+import ConfigType from './ConfigType';
+
+const config: ConfigType = {
+  rpcUrl: 'http://127.0.0.1:8545',
+};
+
+export default config;

--- a/inpage/demo/main.tsx
+++ b/inpage/demo/main.tsx
@@ -5,20 +5,28 @@ import App from './App.tsx';
 import WaxInPage from '../src';
 import './index.css';
 import DemoContext from './DemoContext.ts';
+import config from './config.ts';
 
 WaxInPage.addStylesheet();
 
-const waxInPage = new WaxInPage();
+const waxInPage = new WaxInPage({
+  rpcUrl: config.rpcUrl,
+});
+
 waxInPage.attachGlobals();
 
 const globalRecord = globalThis as Record<string, unknown>;
 globalRecord.ethers = ethers;
 
-// TODO: This is only a good default for owned test networks. Update this when
-// adding network configuration.
-waxInPage.setConfig({
-  ethersPollingInterval: 500,
-});
+if (config.pollingInterval !== undefined) {
+  waxInPage.setConfig({
+    ethersPollingInterval: config.pollingInterval,
+  });
+} else if (config.rpcUrl === 'http://127.0.0.1:8545') {
+  waxInPage.setConfig({
+    ethersPollingInterval: 500,
+  });
+}
 
 const demoContext = new DemoContext(waxInPage);
 

--- a/inpage/package.json
+++ b/inpage/package.json
@@ -6,7 +6,7 @@
   "types": "build/lib/index.d.ts",
   "scripts": {
     "setup": "yarn && scripts/setup.ts",
-    "dev": "concurrently --kill-others vite \"yarn --cwd hardhat hardhat node\"",
+    "dev": "scripts/dev.ts",
     "check-ts": "tsc --noEmit",
     "build": "yarn check-ts && rm -rf build && yarn build:lib && yarn build:demo && yarn build:globalScript && yarn build:packed-lib",
     "build:lib": "tsc -p tsconfig.lib.json",

--- a/inpage/package.json
+++ b/inpage/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "types": "build/lib/index.d.ts",
   "scripts": {
-    "setup": "yarn && yarn --cwd hardhat && yarn --cwd hardhat hardhat compile",
+    "setup": "yarn && scripts/setup.ts",
     "dev": "concurrently --kill-others vite \"yarn --cwd hardhat hardhat node\"",
     "check-ts": "tsc --noEmit",
     "build": "yarn check-ts && rm -rf build && yarn build:lib && yarn build:demo && yarn build:globalScript && yarn build:packed-lib",
@@ -28,6 +28,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@swc/core": "^1.3.75",
     "@types/node": "^20.4.2",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
@@ -46,6 +47,7 @@
     "eslint-plugin-react-refresh": "^0.4.1",
     "events": "^3.3.0",
     "prettier": "^3.0.0",
+    "ts-node": "^10.9.1",
     "typed-emitter": "^2.1.0",
     "typescript": "^5.0.2",
     "vite": "^4.4.0"

--- a/inpage/scripts/dev.ts
+++ b/inpage/scripts/dev.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env ts-node-esm
+
+import concurrently from 'concurrently';
+import config from '../demo/config.ts';
+
+const tasks = ['vite'];
+
+if (config.rpcUrl === 'http://127.0.0.1:8545') {
+  tasks.push('yarn --cwd hardhat hardhat node');
+}
+
+await concurrently(tasks, { killOthers: 'failure' }).result;

--- a/inpage/scripts/helpers/fileExists.ts
+++ b/inpage/scripts/helpers/fileExists.ts
@@ -1,0 +1,13 @@
+import fs from 'fs/promises';
+import projectPath from './projectPath.ts';
+
+export default async function fileExists(projectPathParam: string) {
+  const filePath = projectPath(projectPathParam);
+
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/inpage/scripts/helpers/projectPath.ts
+++ b/inpage/scripts/helpers/projectPath.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+
+const currentFile = new URL(import.meta.url).pathname;
+const projectDir = path.dirname(path.dirname(path.dirname(currentFile)));
+
+export default function projectPath(extraPath: string) {
+  return path.join(projectDir, ...extraPath.split('/'));
+}

--- a/inpage/scripts/helpers/shell.ts
+++ b/inpage/scripts/helpers/shell.ts
@@ -1,0 +1,21 @@
+import { spawn } from 'child_process';
+
+export default async function shell(command: string, args: string[] = []) {
+  const child = spawn(command, args, { stdio: 'inherit' });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Command ${JSON.stringify(
+              command,
+            )} exited with non-zero exit code ${String(code)}`,
+          ),
+        );
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/inpage/scripts/setup.ts
+++ b/inpage/scripts/setup.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env ts-node-esm
+
+/* eslint-disable no-console */
+
+import fs from 'fs/promises';
+import shell from './helpers/shell.ts';
+import fileExists from './helpers/fileExists.ts';
+import projectPath from './helpers/projectPath.ts';
+
+const demoConfigNeeded = !(await fileExists('demo/config.ts'));
+
+if (demoConfigNeeded) {
+  await fs.copyFile(
+    projectPath('demo/config.template.ts'),
+    projectPath('demo/config.ts'),
+  );
+}
+
+await shell('yarn', ['--cwd', projectPath('hardhat')]);
+await shell('yarn', ['--cwd', projectPath('hardhat'), 'hardhat', 'compile']);
+
+console.log('Setup success 🔥');
+
+if (demoConfigNeeded) {
+  console.log('demo/config.ts can be edited to suit your needs');
+}
+
+console.log('Use `yarn dev` to start the dev server');

--- a/inpage/src/EthereumApi.tsx
+++ b/inpage/src/EthereumApi.tsx
@@ -29,6 +29,7 @@ type StrictUserOperation = {
 export default class EthereumApi {
   #waxInPage: WaxInPage;
   #networkUrl = 'http://127.0.0.1:8545';
+  #chainIdPromise: Promise<string>;
 
   #userOps = new Map<
     string,
@@ -46,6 +47,10 @@ export default class EthereumApi {
 
   constructor(waxInPage: WaxInPage) {
     this.#waxInPage = waxInPage;
+
+    this.#chainIdPromise = this.#networkRequest({ method: 'eth_chainId' }).then(
+      (res) => z.string().parse(res),
+    );
   }
 
   async request<M extends string>({
@@ -102,6 +107,8 @@ export default class EthereumApi {
   }
 
   #customHandlers: Partial<EthereumRpc.Handlers> = {
+    eth_chainId: () => this.#chainIdPromise,
+
     eth_requestAccounts: async () => {
       let connectedAccounts =
         await this.#waxInPage.storage.connectedAccounts.get();

--- a/inpage/src/EthereumApi.tsx
+++ b/inpage/src/EthereumApi.tsx
@@ -28,7 +28,7 @@ type StrictUserOperation = {
 
 export default class EthereumApi {
   #waxInPage: WaxInPage;
-  #networkUrl = 'http://127.0.0.1:8545';
+  #rpcUrl: string;
   #chainIdPromise: Promise<string>;
 
   #userOps = new Map<
@@ -45,7 +45,8 @@ export default class EthereumApi {
     }
   >();
 
-  constructor(waxInPage: WaxInPage) {
+  constructor(rpcUrl: string, waxInPage: WaxInPage) {
+    this.#rpcUrl = rpcUrl;
     this.#waxInPage = waxInPage;
 
     this.#chainIdPromise = this.#networkRequest({ method: 'eth_chainId' }).then(
@@ -372,7 +373,7 @@ export default class EthereumApi {
     method: string;
     params?: unknown[];
   }) {
-    const res = await fetch(this.#networkUrl, {
+    const res = await fetch(this.#rpcUrl, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/inpage/src/EthereumRpc.ts
+++ b/inpage/src/EthereumRpc.ts
@@ -5,15 +5,15 @@ namespace EthereumRpc {
   export const emptyParams = z.union([z.tuple([]), z.undefined()]);
 
   export const Transaction = z.object({
-    blockHash: z.string(),
-    blockNumber: z.string(),
+    blockHash: z.union([z.string(), z.null()]),
+    blockNumber: z.union([z.string(), z.null()]),
     from: z.string(),
     gas: z.string(),
     hash: z.string(),
     input: z.string(),
     nonce: z.string(),
     to: z.string(),
-    transactionIndex: z.string(),
+    transactionIndex: z.union([z.string(), z.null()]),
     value: z.string(),
     v: z.string(),
     r: z.string(),

--- a/inpage/src/WaxInPage.tsx
+++ b/inpage/src/WaxInPage.tsx
@@ -33,6 +33,11 @@ const defaultConfig: Config = {
 
 let ethersDefaultPollingInterval = 4000;
 
+type ConstructorOptions = {
+  rpcUrl: string;
+  storage?: WaxStorage;
+};
+
 export type Contracts = {
   greeter: Greeter;
   entryPoint: EntryPoint;
@@ -49,15 +54,15 @@ export default class WaxInPage {
   storage: WaxStorage;
   ethersProvider: ethers.BrowserProvider;
 
-  constructor(storage = makeLocalWaxStorage()) {
-    this.ethereum = new EthereumApi(this);
+  constructor({ rpcUrl, storage = makeLocalWaxStorage() }: ConstructorOptions) {
+    this.ethereum = new EthereumApi(rpcUrl, this);
     this.storage = storage;
     this.ethersProvider = new ethers.BrowserProvider(this.ethereum);
     ethersDefaultPollingInterval = this.ethersProvider.pollingInterval;
   }
 
-  static global() {
-    new WaxInPage().attachGlobals();
+  static global(opt: ConstructorOptions) {
+    new WaxInPage(opt).attachGlobals();
   }
 
   static addStylesheet() {

--- a/inpage/src/global.ts
+++ b/inpage/src/global.ts
@@ -1,4 +1,19 @@
 import './compatibility';
+import { z } from 'zod';
 import WaxInPage from '.';
 
-WaxInPage.global();
+const globalRecord = globalThis as Record<string, unknown>;
+
+const parsedConfig = z
+  .object({
+    rpcUrl: z.string(),
+  })
+  .safeParse(globalRecord.waxInPageConfig);
+
+if (!parsedConfig.success) {
+  throw new Error(parsedConfig.error.toString());
+}
+
+WaxInPage.global({
+  rpcUrl: parsedConfig.data.rpcUrl,
+});

--- a/inpage/tsconfig.json
+++ b/inpage/tsconfig.json
@@ -17,5 +17,9 @@
     "strict": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["*.*", "./**/*"]
+  "include": ["*.*", "./**/*"],
+  "ts-node": {
+    "transpileOnly": true,
+    "swc": true
+  }
 }

--- a/inpage/yarn.lock
+++ b/inpage/yarn.lock
@@ -19,6 +19,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@esbuild/android-arm64@0.18.13":
   version "0.18.13"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.13.tgz#70ef455455654c7800c31ae55ae295d81712238c"
@@ -180,6 +187,24 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@noble/hashes@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
@@ -236,50 +261,100 @@
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.69.tgz#e22032471244ec80c22bee8efc2100e456bb9488"
   integrity sha512-IjZTf12zIPWkV3D7toaLDoJPSkLhQ4fDH8G6/yCJUI27cBFOI3L8LXqptYmISoN5yYdrcnNpdqdapD09JPuNJg==
 
+"@swc/core-darwin-arm64@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.75.tgz#f6b2fb9dd03839ff3153902e09f1772963a1bbb6"
+  integrity sha512-anDnx9L465lGbjB2mvcV54NGHW6illr0IDvVV7JmkabYUVneaRdQvTr0tbHv3xjHnjrK1wuwVOHKV0LcQF2tnQ==
+
 "@swc/core-darwin-x64@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.69.tgz#4c2034ba409b9e061b9e8ad56a762b8bb7815f18"
   integrity sha512-/wBO0Rn5oS5dJI/L9kJRkPAdksVwl5H9nleW/NM3A40N98VV8T7h/i1nO051mxIjq0R6qXVGOWFbBoLrPYucJg==
+
+"@swc/core-darwin-x64@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.75.tgz#b5a4fcc668f15fe664c9bdddac12b7c0685e6c81"
+  integrity sha512-dIHDfrLmeZfr2xwi1whO7AmzdI3HdamgvxthaL+S8L1x8TeczAZEvsmZTjy3s8p3Va4rbGXcb3+uBhmfkqCbfw==
 
 "@swc/core-linux-arm-gnueabihf@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.69.tgz#3d89053b6de2fd8553ce5c5808251246f2870e1e"
   integrity sha512-NShCjMv6Xn8ckMKBRqmprXvUF14+jXY0TcNKXwjYErzoIUFOnG72M36HxT4QEeAtKZ4Eg4CZFE4zlJ27fDp1gg==
 
+"@swc/core-linux-arm-gnueabihf@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.75.tgz#a4b19babc256390790b50d75dd300a3201275f9f"
+  integrity sha512-qeJmvMGrjC6xt+G0R4kVqqxvlhxJx7tTzhcEoWgLJnfvGZiF6SJdsef4OSM7HuReXrlBoEtJbfGPrLJtbV+C0w==
+
 "@swc/core-linux-arm64-gnu@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.69.tgz#df12d3befc5e86555ee561202dc9c279d8865bf3"
   integrity sha512-VRPOJj4idopSHIj1bOVXX0SgaB18R8yZNunb7eXS5ZcjVxAcdvqyIz3RdQX1zaJFCGzcdPLzBRP32DZWWGE8Ng==
+
+"@swc/core-linux-arm64-gnu@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.75.tgz#347e44d12a3fd71e9fc109b68a7fff81696ecbc3"
+  integrity sha512-sqA9JqHEJBF4AdNuwo5zRqq0HC3l31SPsG9zpRa4nRzG5daBBJ80H7fi6PZQud1rfNNq+Q08gjYrdrxwHstvjw==
 
 "@swc/core-linux-arm64-musl@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.69.tgz#8372222a3298fdd0bd18da564a3009614a6c0920"
   integrity sha512-QxeSiZqo5x1X8vq8oUWLibq+IZJcxl9vy0sLUmzdjF2b/Z+qxKP3gutxnb2tzJaHqPVBbEZaILERIGy1qWdumQ==
 
+"@swc/core-linux-arm64-musl@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.75.tgz#ca21e597ff52c0a25848be1838cd923a32963584"
+  integrity sha512-95rQT5xTAL3eKhMJbJbLsZHHP9EUlh1rcrFoLf0gUApoVF8g94QjZ9hYZiI72mMP5WPjgTEXQVnVB9O2GxeaLw==
+
 "@swc/core-linux-x64-gnu@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.69.tgz#6879057d28f261b051fac52daca6c256f3a7fb7d"
   integrity sha512-b+DUlVxYox3BwD3PyTwhLvqtu6TYZtW+S6O0FnttH11o4skHN0XyJ/cUZSI0X2biSmfDsizRDUt1PWPFM+F7SA==
+
+"@swc/core-linux-x64-gnu@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.75.tgz#56abe19475a72bdc5333461b55ca3c2cd60e4611"
+  integrity sha512-If7UpAhnPduMmtC+TSgPpZ1UXZfp2hIpjUFxpeCmHHYLS6Fn/2GZC5hpEiu+wvFJF0hzPh93eNAHa9gUxGUG+w==
 
 "@swc/core-linux-x64-musl@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.69.tgz#bf4f9a74156524211472bb713d34f0bb7265669f"
   integrity sha512-QXjsI+f8n9XPZHUvmGgkABpzN4M9kdSbhqBOZmv3o0AsDGNCA4uVowQqgZoPFAqlJTpwHeDmrv5sQ13HN+LOGw==
 
+"@swc/core-linux-x64-musl@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.75.tgz#bfa90d24071930effeb4514540f89266a6d6957a"
+  integrity sha512-HOhxX0YNHTElCZqIviquka3CGYTN8rSQ6BdFfSk/K0O+ZEHx3qGte0qr+gGLPF/237GxreUkp3OMaWKuURtuCg==
+
 "@swc/core-win32-arm64-msvc@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.69.tgz#8242e4a406d11f0e078da39cf9962695e6b73d2d"
   integrity sha512-wn7A8Ws1fyviuCUB2Vg6IotiZeuqiO1Mz3d+YDae2EYyNpj1kNHvjBip8GHkfGzZG+jVrvG6NHsDo0KO/pGb8A==
+
+"@swc/core-win32-arm64-msvc@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.75.tgz#2fd8ea75ffe1a9153c523b6135b7169266a60e54"
+  integrity sha512-7QPI+mvBXAerVfWahrgBNe+g7fK8PuetxFnZSEmXUcDXvWcdJXAndD7GjAJzbDyjQpLKHbsDKMiHYvfNxZoN/A==
 
 "@swc/core-win32-ia32-msvc@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.69.tgz#68dbd41e200e5db71aa6644d793acff3607862f0"
   integrity sha512-LsFBXtXqxEcVaaOGEZ9X3qdMzobVoJqKv8DnksuDsWcBk+9WCeTz2u/iB+7yZ2HGuPXkCqTRqhFo6FX9aC00kQ==
 
+"@swc/core-win32-ia32-msvc@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.75.tgz#9dae46582027ffeb03f258d05ab797701250d465"
+  integrity sha512-EfABCy4Wlq7O5ShWsm32FgDkSjyeyj/SQ4wnUIvWpkXhgfT1iNXky7KRU1HtX+SmnVk/k/NnabVZpIklYbjtZA==
+
 "@swc/core-win32-x64-msvc@1.3.69":
   version "1.3.69"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.69.tgz#304e1050d59bae21215a15839b05668d48a92837"
   integrity sha512-ieBscU0gUgKjaseFI07tAaGqHvKyweNknPeSYEZOasVZUczhD6fK2GRnVREhv2RB2qdKC/VGFBsgRDMgzq1VLw==
+
+"@swc/core-win32-x64-msvc@1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.75.tgz#c8e6d30c5deed1ae0fa162a42d6d9ef165b8041f"
+  integrity sha512-cTvP0pOD9C3pSp1cwtt85ZsrUkQz8RZfSPhM+jCGxKxmoowDCnInoOQ4Ica/ehyuUnQ4/IstSdYtYpO5yzPDJg==
 
 "@swc/core@^1.3.61":
   version "1.3.69"
@@ -296,6 +371,42 @@
     "@swc/core-win32-arm64-msvc" "1.3.69"
     "@swc/core-win32-ia32-msvc" "1.3.69"
     "@swc/core-win32-x64-msvc" "1.3.69"
+
+"@swc/core@^1.3.75":
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.75.tgz#b06d32144a5be0b7b25dbbff09dcd1ab18e48b67"
+  integrity sha512-YLqd5oZVnaOq/OzkjRSsJUQqAfKYiD0fzUyVUPVlNNCoQEfVfSMcXH80hLmYe9aDH0T/a7qEMjWyIr/0kWqy1A==
+  optionalDependencies:
+    "@swc/core-darwin-arm64" "1.3.75"
+    "@swc/core-darwin-x64" "1.3.75"
+    "@swc/core-linux-arm-gnueabihf" "1.3.75"
+    "@swc/core-linux-arm64-gnu" "1.3.75"
+    "@swc/core-linux-arm64-musl" "1.3.75"
+    "@swc/core-linux-x64-gnu" "1.3.75"
+    "@swc/core-linux-x64-musl" "1.3.75"
+    "@swc/core-win32-arm64-msvc" "1.3.75"
+    "@swc/core-win32-ia32-msvc" "1.3.75"
+    "@swc/core-win32-x64-msvc" "1.3.75"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/color-convert@*":
   version "2.0.0"
@@ -463,7 +574,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.9.0:
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -494,6 +610,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -718,6 +839,11 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -806,6 +932,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1923,6 +2054,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -2540,6 +2676,25 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.14.1:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
@@ -2662,6 +2817,11 @@ utility-types@^3.10.0:
   resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
   integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 vite@^4.4.0:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.4.tgz#b76e6049c0e080cb54e735ad2d18287753752118"
@@ -2749,6 +2909,11 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
inpage now works with external networks!

It's as simple as configuring `rpcUrl` in `demo/config.ts`. `yarn dev` will skip running a node when you set it to something other than `http://127.0.0.1:8545`.

The contracts have these deterministic addresses:

```ts
{
  entryPoint: '0x41d406bdbDD04f273353B4CB2f64d23b2ef9F2B0',
  simpleAccountFactory: '0xAc1A4e82A50bc64096D43d947eDb4AE7ad3C1b5D',
  greeter: '0x9631Ccf03161e6b18B179Be829E601BB6bb645c5',
}
```

You can see them at those addresses on:
- Optimism Goerli: [entryPoint](https://goerli-optimism.etherscan.io/address/0x41d406bdbDD04f273353B4CB2f64d23b2ef9F2B0), [simpleAccountFactory](https://goerli-optimism.etherscan.io/address/0xAc1A4e82A50bc64096D43d947eDb4AE7ad3C1b5D), [greeter](https://goerli-optimism.etherscan.io/address/0x9631Ccf03161e6b18B179Be829E601BB6bb645c5)
- Sepolia: [entryPoint](https://sepolia.etherscan.io/address/0x41d406bdbDD04f273353B4CB2f64d23b2ef9F2B0), [simpleAccountFactory](https://sepolia.etherscan.io/address/0xAc1A4e82A50bc64096D43d947eDb4AE7ad3C1b5D), [greeter](https://sepolia.etherscan.io/address/0x9631Ccf03161e6b18B179Be829E601BB6bb645c5)

These deployments were made by simply using the demo and providing a suitable private key when prompted that the contracts needed to be deployed.

To avoid deploying redundant entry points, we need to add an option to specify the address instead of allowing it to be auto deployed. That will make more sense as part of #36 though.

Resolves #35.