### PR TITLE
More cleanup for account-integrations/safe

### DIFF
--- a/account-integrations/safe/package.json
+++ b/account-integrations/safe/package.json
@@ -33,7 +33,6 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.0",
     "ethers": "^6.4.0",
-    "ethers-v5": "npm:ethers@5.7.2",
     "hardhat": "^2.17.1",
     "hardhat-gas-reporter": "^1.0.8",
     "hardhat-preprocessor": "^0.1.5",

--- a/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
@@ -10,6 +10,7 @@ import {
   Safe__factory,
 } from "../../../typechain-types";
 import sendUserOpAndWait from "../utils/sendUserOpAndWait";
+import receiptOf from "../utils/receiptOf";
 
 const ERC4337_TEST_ENV_VARIABLES_DEFINED =
   typeof process.env.ERC4337_TEST_BUNDLER_URL !== "undefined" &&
@@ -145,12 +146,12 @@ describe("SafeECDSAPlugin", () => {
     );
 
     // Native tokens for the pre-fund 💸
-    await (
-      await userWallet.sendTransaction({
+    await receiptOf(
+      userWallet.sendTransaction({
         to: deployedAddress,
         value: ethers.parseEther("100"),
-      })
-    ).wait();
+      }),
+    );
 
     const unsignedUserOperation: UserOperationStruct = {
       sender: deployedAddress,

--- a/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
@@ -2,7 +2,6 @@ import hre from "hardhat";
 import { expect } from "chai";
 import { AddressZero } from "@ethersproject/constants";
 import { getBytes, concat, resolveProperties, ethers } from "ethers";
-import { ethers as ethersV5 } from "ethers-v5";
 import { UserOperationStruct } from "@account-abstraction/contracts";
 import { getUserOpHash } from "@account-abstraction/utils";
 import { calculateProxyAddress } from "../utils/calculateProxyAddress";
@@ -10,7 +9,7 @@ import {
   SafeProxyFactory__factory,
   Safe__factory,
 } from "../../../typechain-types";
-import sleep from "../utils/sleep";
+import sendUserOpAndWait from "../utils/sendUserOpAndWait";
 
 const ERC4337_TEST_ENV_VARIABLES_DEFINED =
   typeof process.env.ERC4337_TEST_BUNDLER_URL !== "undefined" &&
@@ -28,7 +27,7 @@ const MNEMONIC = process.env.MNEMONIC;
 
 describe("SafeECDSAPlugin", () => {
   const setupTests = async () => {
-    const bundlerProvider = new ethersV5.providers.JsonRpcProvider(BUNDLER_URL);
+    const bundlerProvider = new ethers.JsonRpcProvider(BUNDLER_URL);
     const provider = new ethers.JsonRpcProvider(NODE_URL);
     const userWallet = ethers.Wallet.fromPhrase(MNEMONIC!).connect(provider);
 
@@ -87,8 +86,7 @@ describe("SafeECDSAPlugin", () => {
       userWallet.address,
       { gasLimit: 1_000_000 },
     );
-    // The bundler uses a different node, so we need to allow it sometime to sync
-    await sleep(5000);
+    await safeECDSAPlugin.deploymentTransaction()?.wait();
 
     const feeData = await provider.getFeeData();
     if (!feeData.maxFeePerGas || !feeData.maxPriorityFeePerGas) {
@@ -147,12 +145,12 @@ describe("SafeECDSAPlugin", () => {
     );
 
     // Native tokens for the pre-fund 💸
-    await userWallet.sendTransaction({
-      to: deployedAddress,
-      value: ethers.parseEther("100"),
-    });
-    // The bundler uses a different node, so we need to allow it sometime to sync
-    await sleep(5000);
+    await (
+      await userWallet.sendTransaction({
+        to: deployedAddress,
+        value: ethers.parseEther("100"),
+      })
+    ).wait();
 
     const unsignedUserOperation: UserOperationStruct = {
       sender: deployedAddress,
@@ -193,12 +191,7 @@ describe("SafeECDSAPlugin", () => {
 
     const recipientBalanceBefore = await provider.getBalance(recipientAddress);
 
-    await bundlerProvider.send("eth_sendUserOperation", [
-      userOperation,
-      ENTRYPOINT_ADDRESS,
-    ]);
-    // The bundler uses a different node, so we need to allow it sometime to sync
-    await sleep(5000);
+    await sendUserOpAndWait(userOperation, ENTRYPOINT_ADDRESS, bundlerProvider);
 
     const recipientBalanceAfter = await provider.getBalance(recipientAddress);
 

--- a/account-integrations/safe/test/hardhat/integration/SafeWebAuthnPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/integration/SafeWebAuthnPlugin.test.ts
@@ -9,6 +9,7 @@ import {
   Safe__factory,
 } from "../../../typechain-types";
 import sendUserOpAndWait from "../utils/sendUserOpAndWait";
+import receiptOf from "../utils/receiptOf";
 
 const ERC4337_TEST_ENV_VARIABLES_DEFINED =
   typeof process.env.ERC4337_TEST_BUNDLER_URL !== "undefined" &&
@@ -186,12 +187,12 @@ describe("SafeWebAuthnPlugin", () => {
     );
 
     // Native tokens for the pre-fund 💸
-    await (
-      await userWallet.sendTransaction({
+    await receiptOf(
+      userWallet.sendTransaction({
         to: deployedAddress,
         value: ethers.parseEther("100"),
-      })
-    ).wait();
+      }),
+    );
 
     const userOperationWithoutGasFields = {
       sender: deployedAddress,

--- a/account-integrations/safe/test/hardhat/utils/receiptOf.ts
+++ b/account-integrations/safe/test/hardhat/utils/receiptOf.ts
@@ -1,0 +1,10 @@
+import { ethers } from "ethers";
+
+export default async function receiptOf(
+  txResponseOrPromise:
+    | ethers.TransactionResponse
+    | Promise<ethers.TransactionResponse>,
+) {
+  const txResponse = await txResponseOrPromise;
+  return await txResponse.wait();
+}

--- a/account-integrations/safe/test/hardhat/utils/sendUserOpAndWait.ts
+++ b/account-integrations/safe/test/hardhat/utils/sendUserOpAndWait.ts
@@ -1,0 +1,36 @@
+import { UserOperationStruct } from "@account-abstraction/contracts";
+import { ethers } from "ethers";
+import sleep from "./sleep";
+
+export default async function sendUserOpAndWait(
+  userOp: UserOperationStruct,
+  entryPoint: string,
+  bundlerProvider: ethers.JsonRpcProvider,
+  pollingDelay = 100,
+  maxAttempts = 200,
+) {
+  const userOpHash = (await bundlerProvider.send("eth_sendUserOperation", [
+    userOp,
+    entryPoint,
+  ])) as string;
+
+  let receipt: { success: boolean } | null = null;
+
+  let attempts = 0;
+
+  while (attempts < maxAttempts && receipt === null) {
+    await sleep(pollingDelay);
+
+    receipt = (await bundlerProvider.send("eth_getUserOperationReceipt", [
+      userOpHash,
+    ])) as { success: boolean } | null;
+
+    attempts++;
+  }
+
+  if (receipt === null) {
+    throw new Error(`Could not get receipt after ${maxAttempts} attempts`);
+  }
+
+  return receipt;
+}

--- a/account-integrations/safe/yarn.lock
+++ b/account-integrations/safe/yarn.lock
@@ -2627,7 +2627,22 @@ ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-"ethers-v5@npm:ethers@5.7.2", ethers@^5.5.3, ethers@^5.7.0, ethers@^5.7.1:
+ethers@^4.0.40:
+  version "4.0.49"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.49.tgz#0eb0e9161a0c8b4761be547396bbe2fb121a8894"
+  integrity sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@^5.5.3, ethers@^5.7.0, ethers@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -2662,21 +2677,6 @@ ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4:
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
-
-ethers@^4.0.40:
-  version "4.0.49"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.49.tgz#0eb0e9161a0c8b4761be547396bbe2fb121a8894"
-  integrity sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==
-  dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.11.9"
-    elliptic "6.5.4"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
 
 ethers@^6.4.0:
   version "6.6.7"


### PR DESCRIPTION
# *Dependent PR*

This PR depends on #86. Please merge that PR first.

## About

- Remove ethers-v5 (consolidate on v6 only)
- Improve syncing with bundler using APIs instead of waiting 5 seconds
- `sendUserOpAndWait` sends a user operation and polls for the receipt
- `receiptOf` avoids double await pattern, alleviating the temptation to not wait for the receipt

`yarn hardhat test` is now much faster (not foundry fast, but still).