### PR TITLE
Make dev faster

### DIFF
--- a/account-integrations/safe/script/deploy_all.ts
+++ b/account-integrations/safe/script/deploy_all.ts
@@ -13,6 +13,7 @@ import {
   Safe__factory,
   EntryPoint__factory,
 } from "../typechain-types";
+import makeDevFaster from "../test/hardhat/utils/makeDevFaster";
 
 async function deploy() {
   const contractFactories = [
@@ -30,6 +31,7 @@ async function deploy() {
   ];
 
   const provider = new ethers.JsonRpcProvider(process.env.NODE_URL);
+  await makeDevFaster(provider);
   const hdNode = ethers.HDNodeWallet.fromPhrase(process.env.MNEMONIC!);
   const wallet = new ethers.Wallet(hdNode.privateKey, provider);
 

--- a/account-integrations/safe/script/start.sh
+++ b/account-integrations/safe/script/start.sh
@@ -28,11 +28,10 @@ docker run --rm -i --name $CONTAINER -p 8545:8545 ethereum/client-go:v1.10.26 \
   --rpc.allow-unprotected-txs \
   --rpc.txfeecap 2 \
   --dev \
+  --dev.period=0 \
   --verbosity 2 \
   --nodiscover \
   --maxpeers 0 \
-  --mine \
-  --miner.threads 1 \
   --networkid 1337 \
   &
 

--- a/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/integration/SafeECDSAPlugin.test.ts
@@ -14,6 +14,7 @@ import {
 import sendUserOpAndWait from "../utils/sendUserOpAndWait";
 import receiptOf from "../utils/receiptOf";
 import SafeSingletonFactory from "../utils/SafeSingletonFactory";
+import makeDevFaster from "../utils/makeDevFaster";
 
 const ERC4337_TEST_ENV_VARIABLES_DEFINED =
   typeof process.env.ERC4337_TEST_BUNDLER_URL !== "undefined" &&
@@ -29,6 +30,7 @@ describe("SafeECDSAPlugin", () => {
   const setupTests = async () => {
     const bundlerProvider = new ethers.JsonRpcProvider(BUNDLER_URL);
     const provider = new ethers.JsonRpcProvider(NODE_URL);
+    await makeDevFaster(provider);
     const userWallet = ethers.Wallet.fromPhrase(MNEMONIC!).connect(provider);
 
     const entryPoints = (await bundlerProvider.send(

--- a/account-integrations/safe/test/hardhat/integration/SafeWebAuthnPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/integration/SafeWebAuthnPlugin.test.ts
@@ -11,6 +11,7 @@ import {
 import sendUserOpAndWait from "../utils/sendUserOpAndWait";
 import receiptOf from "../utils/receiptOf";
 import SafeSingletonFactory from "../utils/SafeSingletonFactory";
+import makeDevFaster from "../utils/makeDevFaster";
 
 const ERC4337_TEST_ENV_VARIABLES_DEFINED =
   typeof process.env.ERC4337_TEST_BUNDLER_URL !== "undefined" &&
@@ -26,6 +27,7 @@ describe("SafeWebAuthnPlugin", () => {
   const setupTests = async () => {
     const bundlerProvider = new ethers.JsonRpcProvider(BUNDLER_URL);
     const provider = new ethers.JsonRpcProvider(NODE_URL);
+    await makeDevFaster(provider);
     const userWallet = ethers.Wallet.fromPhrase(MNEMONIC!).connect(provider);
 
     const entryPoints = (await bundlerProvider.send(

--- a/account-integrations/safe/test/hardhat/utils/makeDevFaster.ts
+++ b/account-integrations/safe/test/hardhat/utils/makeDevFaster.ts
@@ -1,0 +1,9 @@
+import { ethers } from "ethers";
+
+export default async function makeDevFaster(provider: ethers.JsonRpcProvider) {
+  const chainId = (await provider.getNetwork()).chainId;
+
+  if (chainId === 1337n || chainId === 31337n) {
+    provider.pollingInterval = 100;
+  }
+}


### PR DESCRIPTION
- Set `pollingInterval` to 100ms if chain id is 1337 or 31337 (default = 4000ms)
- Use `dev.period=0` for instant sealing and don't enable mining

This makes `./scripts/start.sh` and `yarn hardhat test` much faster.

Before:

![Screen Shot 2023-09-22 at 3 40 29 pm](https://github.com/getwax/wax/assets/9291586/47138875-97a3-4621-99b6-ce09d64c8eab)

After:

![Screen Shot 2023-09-22 at 3 40 40 pm](https://github.com/getwax/wax/assets/9291586/24cb7ecc-938c-413f-aa16-4deef4ece8f8)