### PR TITLE
Add script for starting with hardhat

### DIFF
--- a/account-integrations/safe/script/start-hardhat.sh
+++ b/account-integrations/safe/script/start-hardhat.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+set -meuo pipefail
+
+function cleanup {
+  docker stop $CONTAINER || true
+  jobs -p | xargs kill
+}
+
+trap cleanup EXIT
+trap cleanup INT
+
+yarn hardhat node &
+
+echo $SCRIPT_DIR
+
+"$SCRIPT_DIR/wait-for-rpc.sh"
+
+yarn hardhat run "$SCRIPT_DIR/deploy_all.ts" --network localhost
+
+fg


### PR DESCRIPTION
Just a variation of `./script/start.sh` which uses hardhat instead of geth.

This requires using the bundler in unsafe mode.

Using hardhat can be advantageous for the different diagnostics it provides, especially integration with `console.log`.