### PR TITLE
Use account-level compression in in-page demo

### DIFF
--- a/demos/inpage/.eslintrc.cjs
+++ b/demos/inpage/.eslintrc.cjs
@@ -120,5 +120,7 @@ module.exports = {
     'no-constant-condition': 'off',
     'no-underscore-dangle': 'off',
     'consistent-return': 'off',
+    'no-plusplus': 'off',
+    'no-bitwise': 'off',
   },
 };

--- a/demos/inpage/demo/ConfigType.ts
+++ b/demos/inpage/demo/ConfigType.ts
@@ -1,5 +1,6 @@
 type ConfigType = {
   logRequests?: boolean;
+  logBytes?: boolean;
   rpcUrl: string;
   bundlerRpcUrl?: string;
   pollingInterval?: number;

--- a/demos/inpage/demo/LinksPage.tsx
+++ b/demos/inpage/demo/LinksPage.tsx
@@ -50,6 +50,9 @@ const LinksPage = () => {
       <Button secondary onPress={() => setPath('/greeter')}>
         Greeter dApp
       </Button>
+      <Button secondary onPress={() => setPath('/sendEth')}>
+        Send ETH
+      </Button>
       <Button
         secondary
         onPress={async () => {

--- a/demos/inpage/demo/LinksPage.tsx
+++ b/demos/inpage/demo/LinksPage.tsx
@@ -47,11 +47,11 @@ const LinksPage = () => {
       >
         Add Funds
       </Button>
-      <Button secondary onPress={() => setPath('/greeter')}>
-        Greeter dApp
-      </Button>
       <Button secondary onPress={() => setPath('/sendEth')}>
         Send ETH
+      </Button>
+      <Button secondary onPress={() => setPath('/greeter')}>
+        Greeter dApp
       </Button>
       <Button
         secondary

--- a/demos/inpage/demo/PageRouter.tsx
+++ b/demos/inpage/demo/PageRouter.tsx
@@ -1,5 +1,6 @@
 import GreeterDApp from './GreeterDApp';
 import LinksPage from './LinksPage';
+import SendEthPage from './SendEthPage';
 import usePath from './usePath';
 
 const PageRouter = () => {
@@ -11,6 +12,10 @@ const PageRouter = () => {
 
   if (path === '/greeter') {
     return <GreeterDApp />;
+  }
+
+  if (path === '/sendEth') {
+    return <SendEthPage />;
   }
 
   return <>Not found</>;

--- a/demos/inpage/demo/SendEthPage.css
+++ b/demos/inpage/demo/SendEthPage.css
@@ -1,0 +1,11 @@
+.send-eth-page {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  gap: 1em;
+}
+
+.send-eth-page input {
+  width: 100%;
+  padding: 0.5em;
+}

--- a/demos/inpage/demo/SendEthPage.tsx
+++ b/demos/inpage/demo/SendEthPage.tsx
@@ -1,0 +1,66 @@
+import './SendEthPage.css';
+import { useState } from 'react';
+import { ethers } from 'ethers';
+import Button from '../src/Button';
+import Heading from '../src/Heading';
+import DemoContext from './DemoContext';
+import Loading from './Loading';
+import useRefresh from './useRefresh';
+import runAsync from './helpers/runAsync';
+
+const SendEthPage = () => {
+  const demo = DemoContext.use();
+  const signer = demo.useSigner();
+  const refresh = useRefresh();
+
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+
+  if (!signer) {
+    return (
+      <Loading>
+        <Heading>Send ETH</Heading>
+        <div>Waiting for signer</div>
+      </Loading>
+    );
+  }
+
+  return (
+    <div className="send-eth-page">
+      <Heading>Send ETH</Heading>
+      <div>
+        <input
+          type="text"
+          onInput={(e) => setRecipient(e.currentTarget.value)}
+          placeholder="Recipient address"
+        />
+      </div>
+      <div>
+        <input
+          type="text"
+          onInput={(e) => setAmount(e.currentTarget.value)}
+          placeholder="Amount"
+        />
+      </div>
+      <div>
+        <Button
+          onPress={async () => {
+            await (
+              await signer.sendTransaction({
+                to: recipient,
+                value: ethers.parseEther(amount),
+              })
+            ).wait();
+
+            runAsync(() => demo.refreshBalance());
+            refresh();
+          }}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default SendEthPage;

--- a/demos/inpage/demo/config.template.ts
+++ b/demos/inpage/demo/config.template.ts
@@ -11,6 +11,7 @@ import ConfigType from './ConfigType';
 
 const config: ConfigType = {
   logRequests: true,
+  logBytes: true,
   rpcUrl: 'http://127.0.0.1:8545',
 
   // Uncomment this with the url of a bundler to enable using an external

--- a/demos/inpage/demo/main.tsx
+++ b/demos/inpage/demo/main.tsx
@@ -31,6 +31,7 @@ if (config.pollingInterval !== undefined) {
 
 waxInPage.setConfig({
   logRequests: config.logRequests,
+  logBytes: config.logBytes,
 });
 
 const demoContext = new DemoContext(waxInPage);

--- a/demos/inpage/hardhat/contracts/imports.sol
+++ b/demos/inpage/hardhat/contracts/imports.sol
@@ -7,3 +7,7 @@ import {SimpleAccountFactory} from "account-abstraction/contracts/samples/Simple
 import {Safe} from "../lib/account-integrations/safe/lib/safe-contracts/contracts/Safe.sol";
 import {SafeECDSAFactory} from "../lib/account-integrations/safe/src/SafeECDSAFactory.sol";
 import {SafeECDSAPlugin} from "../lib/account-integrations/safe/src/SafeECDSAPlugin.sol";
+import {SafeCompressionFactory} from "../lib/account-integrations/safe/src/SafeCompressionFactory.sol";
+import {SafeCompressionPlugin} from "../lib/account-integrations/safe/src/SafeCompressionPlugin.sol";
+import {FallbackDecompressor} from "../lib/account-integrations/compression/src/decompressors/FallbackDecompressor.sol";
+import {AddressRegistry} from "../lib/account-integrations/compression/src/AddressRegistry.sol";

--- a/demos/inpage/src/EthereumApi.tsx
+++ b/demos/inpage/src/EthereumApi.tsx
@@ -443,6 +443,8 @@ export default class EthereumApi {
         blockNumber: receipt.receipt.blockNumber,
         from: receipt.sender,
         gas: receipt.actualGasUsed,
+        gasUsed: receipt.actualGasUsed,
+        cumulativeGasUsed: receipt.receipt.cumulativeGasUsed ?? '0x0',
         hash: receipt.userOpHash,
         input: userOp.callData,
         nonce: receipt.nonce,
@@ -462,7 +464,25 @@ export default class EthereumApi {
         gasPrice: receipt.actualGasCost,
         maxFeePerGas: `0x${userOp.maxFeePerGas.toString(16)}`,
         maxPriorityFeePerGas: `0x${userOp.maxPriorityFeePerGas.toString(16)}`,
+        logs: [], // TODO
       } satisfies EthereumRpc.TransactionReceipt;
+    },
+
+    eth_getTransactionReceipt: async (txHash) => {
+      const opInfo = this.#userOps.get(txHash);
+
+      if (opInfo === undefined) {
+        return await ethereumRequest({
+          url: this.#rpcUrl,
+          method: 'eth_getTransactionReceipt',
+          params: [txHash],
+        });
+      }
+
+      return await this.request({
+        method: 'eth_getTransactionByHash',
+        params: [txHash],
+      });
     },
 
     eth_sendUserOperation: async (userOp) =>

--- a/demos/inpage/src/EthereumApi.tsx
+++ b/demos/inpage/src/EthereumApi.tsx
@@ -9,6 +9,7 @@ import IBundler from './bundlers/IBundler';
 import waxPrivate from './waxPrivate';
 import ethereumRequest from './ethereumRequest';
 import calculateUserOpHash from './helpers/calculateUserOpHash';
+import { hexLen } from './helpers/encodeUtils';
 
 // We need a UserOperation in order to estimate the gas fields of a
 // UserOperation, so we use these values as placeholders.
@@ -310,6 +311,8 @@ export default class EthereumApi {
       );
 
       const callData = await account.encodeActions(actions);
+
+      this.#waxInPage.logBytes('userOp.calldata', callData);
 
       let nonce: bigint;
 

--- a/demos/inpage/src/EthereumRpc.ts
+++ b/demos/inpage/src/EthereumRpc.ts
@@ -12,6 +12,8 @@ namespace EthereumRpc {
     blockNumber: z.union([z.string(), z.null()]),
     from: z.string(),
     gas: z.optional(z.string()),
+    gasUsed: z.optional(z.string()),
+    cumulativeGasUsed: z.optional(z.string()),
     hash: z.optional(z.string()),
     input: z.optional(z.string()),
     nonce: z.optional(z.string()),
@@ -27,6 +29,7 @@ namespace EthereumRpc {
     gasPrice: z.optional(z.string()),
     maxFeePerGas: z.optional(z.string()),
     maxPriorityFeePerGas: z.optional(z.string()),
+    logs: z.optional(z.array(z.unknown())),
   });
 
   export type TransactionReceipt = z.infer<typeof TransactionReceipt>;
@@ -104,6 +107,10 @@ namespace EthereumRpc {
       output: z.string(),
     },
     eth_getTransactionByHash: {
+      params: z.tuple([z.string()]),
+      output: z.union([z.null(), TransactionReceipt]),
+    },
+    eth_getTransactionReceipt: {
       params: z.tuple([z.string()]),
       output: z.union([z.null(), TransactionReceipt]),
     },

--- a/demos/inpage/src/WaxInPage.tsx
+++ b/demos/inpage/src/WaxInPage.tsx
@@ -40,9 +40,11 @@ import ChoicePopup from './ChoicePopup';
 import never from './helpers/never';
 import SimpleAccountWrapper from './accounts/SimpleAccountWrapper';
 import SafeCompressionAccountWrapper from './accounts/SafeCompressionAccountWrapper';
+import { hexLen } from './helpers/encodeUtils';
 
 type Config = {
   logRequests?: boolean;
+  logBytes?: boolean;
   requirePermission: boolean;
   deployContractsIfNeeded: boolean;
   ethersPollingInterval?: number;
@@ -395,5 +397,19 @@ export default class WaxInPage {
     }
 
     never(choice);
+  }
+
+  logBytes(description: string, bytes: string) {
+    if (this.getConfig('logBytes')) {
+      // eslint-disable-next-line no-console
+      console.log(
+        'logBytes:',
+        description,
+        'is',
+        hexLen(bytes),
+        'bytes:',
+        bytes,
+      );
+    }
   }
 }

--- a/demos/inpage/src/WaxInPage.tsx
+++ b/demos/inpage/src/WaxInPage.tsx
@@ -333,7 +333,21 @@ export default class WaxInPage {
     await this.storage.connectedAccounts.clear();
   }
 
-  async _getAccount(waxPrivateParam: symbol): Promise<IAccount> {
+  async _getAccount(waxPrivateParam: symbol): Promise<IAccount | undefined> {
+    if (waxPrivateParam !== waxPrivate) {
+      throw new Error('This method is private to the waxInPage library');
+    }
+
+    const existingAccounts = await this.storage.accounts.get();
+
+    if (existingAccounts.length === 0) {
+      return undefined;
+    }
+
+    return await makeAccountWrapper(existingAccounts[0], this);
+  }
+
+  async _getOrCreateAccount(waxPrivateParam: symbol): Promise<IAccount> {
     if (waxPrivateParam !== waxPrivate) {
       throw new Error('This method is private to the waxInPage library');
     }

--- a/demos/inpage/src/accounts/AccountData.ts
+++ b/demos/inpage/src/accounts/AccountData.ts
@@ -5,11 +5,18 @@ import SimpleAccountWrapper, {
 import WaxInPage from '..';
 import never from '../helpers/never';
 import IAccount from './IAccount';
-import SafeECDSAPluginAccount, {
+import SafeECDSAAccountWrapper, {
   SafeECDSAAccountData,
 } from './SafeECDSAAccountWrapper';
+import SafeCompressionAccountWrapper, {
+  SafeCompressionAccountData,
+} from './SafeCompressionAccountWrapper';
 
-const AccountData = z.union([SimpleAccountData, SafeECDSAAccountData]);
+const AccountData = z.union([
+  SimpleAccountData,
+  SafeECDSAAccountData,
+  SafeCompressionAccountData,
+]);
 
 type AccountData = z.infer<typeof AccountData>;
 
@@ -25,7 +32,11 @@ export async function makeAccountWrapper(
   }
 
   if (data.type === 'SafeECDSAAccount') {
-    return SafeECDSAPluginAccount.fromData(data, waxInPage);
+    return SafeECDSAAccountWrapper.fromData(data, waxInPage);
+  }
+
+  if (data.type === 'SafeCompressionAccount') {
+    return SafeCompressionAccountWrapper.fromData(data, waxInPage);
   }
 
   return never(data);

--- a/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
@@ -1,0 +1,187 @@
+import { ethers } from 'ethers';
+import { z } from 'zod';
+import {
+  SafeCompressionPlugin,
+  SafeCompressionPlugin__factory,
+} from '../../hardhat/typechain-types';
+import EthereumRpc from '../EthereumRpc';
+import IAccount from './IAccount';
+import WaxInPage from '..';
+import { SafeCompressionFactory } from '../../hardhat/typechain-types/lib/account-integrations/safe/src/SafeCompressionFactory';
+import receiptOf from '../helpers/receiptOf';
+import {
+  encodeBitStack,
+  encodePseudoFloat,
+  encodeRegIndex,
+  encodeVLQ,
+  hexJoin,
+  hexLen,
+} from '../helpers/encodeUtils';
+
+export const SafeCompressionAccountData = z.object({
+  type: z.literal('SafeCompressionAccount'),
+  address: z.string(),
+  privateKey: z.string(),
+  ownerAddress: z.string(),
+});
+
+export type SafeCompressionAccountData = z.infer<
+  typeof SafeCompressionAccountData
+>;
+
+// Cost of validating a signature or whatever verification method is in place.
+const baseVerificationGas = 100_000n;
+
+export default class SafeCompressionAccountWrapper implements IAccount {
+  type = 'SafeCompressionAccount';
+
+  constructor(
+    public address: string,
+    public privateKey: string,
+    public ownerAddress: string,
+    public waxInPage: WaxInPage,
+  ) {}
+
+  static fromData(data: SafeCompressionAccountData, waxInPage: WaxInPage) {
+    return new SafeCompressionAccountWrapper(
+      data.address,
+      data.privateKey,
+      data.ownerAddress,
+      waxInPage,
+    );
+  }
+
+  toData(): SafeCompressionAccountData {
+    return {
+      type: 'SafeCompressionAccount',
+      address: this.address,
+      privateKey: this.privateKey,
+      ownerAddress: this.ownerAddress,
+    };
+  }
+
+  static async createRandom(
+    waxInPage: WaxInPage,
+  ): Promise<SafeCompressionAccountWrapper> {
+    const contracts = await waxInPage.getContracts();
+
+    const wallet = ethers.Wallet.createRandom();
+
+    const admin = await waxInPage.requestAdminAccount('deploy-account');
+
+    const createArgs = [
+      contracts.safe,
+      contracts.entryPoint,
+      contracts.fallbackDecompressor,
+      wallet,
+      0,
+    ] satisfies Parameters<SafeCompressionFactory['create']>;
+
+    const address = await contracts.safeCompressionFactory.create.staticCall(
+      ...createArgs,
+    );
+
+    await receiptOf(
+      contracts.safeCompressionFactory.connect(admin).create(...createArgs),
+    );
+
+    return new SafeCompressionAccountWrapper(
+      address,
+      wallet.privateKey,
+      wallet.address,
+      waxInPage,
+    );
+  }
+
+  getContract(): SafeCompressionPlugin {
+    return SafeCompressionPlugin__factory.connect(
+      this.address,
+      this.waxInPage.ethersProvider,
+    );
+  }
+
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+  async makeInitCode(): Promise<string> {
+    throw new Error(
+      [
+        'SafeCompressionAccount does not use initCode (it must be created',
+        'before use)',
+      ].join(' '),
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await, class-methods-use-this
+  async encodeActions(actions: EthereumRpc.Action[]): Promise<string> {
+    let stream = '';
+    const bits: boolean[] = [];
+
+    for (const action of actions) {
+      const isAddressRegistered = false;
+      const addressIndex = 0n;
+
+      // TODO: Find addressIndex
+      // for (let j = 0; j < /* registeredAddresses.length */ 0; j++) {
+      //   // if (registeredAddresses[j].addr == action.to) {
+      //   //     isAddressRegistered = true;
+      //   //     addressIndex = registeredAddresses[j].id;
+      //   //     break;
+      //   // }
+      // }
+
+      bits.push(isAddressRegistered);
+
+      let toBytes = '';
+
+      if (isAddressRegistered) {
+        toBytes = encodeRegIndex(addressIndex);
+      } else {
+        toBytes = action.to;
+      }
+
+      stream = hexJoin([
+        stream,
+        toBytes,
+        encodePseudoFloat(BigInt(action.value ?? 0)),
+        encodeVLQ(BigInt(hexLen(action.data ?? '0x'))),
+        action.data ?? '0x',
+      ]);
+    }
+
+    stream = hexJoin([
+      encodeVLQ(BigInt(actions.length)),
+      encodeBitStack(bits),
+      stream,
+    ]);
+
+    return SafeCompressionPlugin__factory.createInterface().encodeFunctionData(
+      'decompressAndPerform',
+      [stream],
+    );
+  }
+
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+  async estimateVerificationGas(
+    _userOp: EthereumRpc.UserOperation,
+  ): Promise<bigint> {
+    // TODO: estimateGas on validateUserOp?
+    return baseVerificationGas;
+  }
+
+  async getNonce(): Promise<bigint> {
+    const contracts = await this.waxInPage.getContracts();
+
+    // TODO: Why does this give a different result to
+    // this.getContract().getNonce()?
+    // (And why does that alternative give the wrong answer?)
+    return await contracts.entryPoint.getNonce(this.address, 0);
+  }
+
+  async sign(
+    _userOp: EthereumRpc.UserOperation,
+    userOpHash: string,
+  ): Promise<string> {
+    const ownerWallet = new ethers.Wallet(this.privateKey);
+
+    return await ownerWallet.signMessage(ethers.getBytes(userOpHash));
+  }
+}

--- a/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
@@ -112,7 +112,7 @@ export default class SafeCompressionAccountWrapper implements IAccount {
 
   // eslint-disable-next-line @typescript-eslint/require-await, class-methods-use-this
   async encodeActions(actions: EthereumRpc.Action[]): Promise<string> {
-    let stream = '';
+    let stream = '0x';
     const bits: boolean[] = [];
 
     for (const action of actions) {
@@ -130,7 +130,7 @@ export default class SafeCompressionAccountWrapper implements IAccount {
 
       bits.push(isAddressRegistered);
 
-      let toBytes = '';
+      let toBytes;
 
       if (isAddressRegistered) {
         toBytes = encodeRegIndex(addressIndex);

--- a/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
@@ -116,23 +116,15 @@ export default class SafeCompressionAccountWrapper implements IAccount {
     const bits: boolean[] = [];
 
     for (const action of actions) {
-      const isAddressRegistered = false;
-      const addressIndex = 0n;
+      const addressIndex: bigint | undefined = undefined;
 
-      // TODO: Find addressIndex
-      // for (let j = 0; j < /* registeredAddresses.length */ 0; j++) {
-      //   // if (registeredAddresses[j].addr == action.to) {
-      //   //     isAddressRegistered = true;
-      //   //     addressIndex = registeredAddresses[j].id;
-      //   //     break;
-      //   // }
-      // }
+      // TODO: Find addressIndex using event logs (see issue #122)
 
-      bits.push(isAddressRegistered);
+      bits.push(addressIndex !== undefined);
 
       let toBytes;
 
-      if (isAddressRegistered) {
+      if (addressIndex !== undefined) {
         toBytes = encodeRegIndex(addressIndex);
       } else {
         toBytes = action.to;

--- a/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
@@ -153,6 +153,8 @@ export default class SafeCompressionAccountWrapper implements IAccount {
       stream,
     ]);
 
+    this.waxInPage.logBytes('stream argument of decompressAndPerform', stream);
+
     return SafeCompressionPlugin__factory.createInterface().encodeFunctionData(
       'decompressAndPerform',
       [stream],

--- a/demos/inpage/src/bundlers/SimulatedBundler.ts
+++ b/demos/inpage/src/bundlers/SimulatedBundler.ts
@@ -38,7 +38,7 @@ export default class SimulatedBundler implements IBundler {
     userOp: EthereumRpc.UserOperation,
   ): Promise<EthereumRpc.UserOperationGasEstimate> {
     const contracts = await this.#waxInPage.getContracts();
-    const account = await this.#waxInPage._getAccount(waxPrivate);
+    const account = await this.#waxInPage._getOrCreateAccount(waxPrivate);
 
     // We need a beneficiary address to measure the encoded calldata, but
     // there's no need for it to be correct.

--- a/demos/inpage/src/bundlers/SimulatedBundler.ts
+++ b/demos/inpage/src/bundlers/SimulatedBundler.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import WaxInPage from '..';
 import EthereumRpc from '../EthereumRpc';
 import measureCalldataGas from '../measureCalldataGas';
@@ -27,9 +28,12 @@ export default class SimulatedBundler implements IBundler {
 
     // *not* the confirmation, just the response (don't add .wait(), that's
     // wrong).
-    await contracts.entryPoint
+    const txResponse = await contracts.entryPoint
       .connect(adminAccount)
       .handleOps([userOp], adminAccount.getAddress());
+
+    const tx = ethers.Transaction.from(txResponse);
+    this.#waxInPage.logBytes('EntryPoint tx', tx.serialized);
 
     return await contracts.entryPoint.getUserOpHash(userOp);
   }

--- a/demos/inpage/src/ethereumRequest.ts
+++ b/demos/inpage/src/ethereumRequest.ts
@@ -70,5 +70,5 @@ function parseResponse<M extends string>(
     });
   }
 
-  return parsedResponse.data as EthereumRpc.Response<M>;
+  return response as EthereumRpc.Response<M>;
 }

--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -2,6 +2,10 @@ export function hexJoin(hexStrings: string[]) {
   return `0x${hexStrings.map(remove0x).join('')}`;
 }
 
+export function hexLen(hexString: string) {
+  return (hexString.length - 2) / 2;
+}
+
 export function remove0x(hexString: string) {
   if (!hexString.startsWith('0x')) {
     throw new Error('Expected 0x prefix');

--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -1,0 +1,111 @@
+export function hexJoin(hexStrings: string[]) {
+  return `0x${hexStrings.map(remove0x).join('')}`;
+}
+
+export function remove0x(hexString: string) {
+  if (!hexString.startsWith('0x')) {
+    throw new Error('Expected 0x prefix');
+  }
+
+  return hexString.slice(2);
+}
+
+export function encodeVLQ(xParam: bigint) {
+  let x = xParam;
+  const segments: bigint[] = [];
+
+  while (true) {
+    const segment = x % 128n;
+    segments.unshift(segment);
+    x -= segment;
+    x /= 128n;
+
+    if (x === 0n) {
+      break;
+    }
+  }
+
+  let result = '0x';
+
+  for (let i = 0; i < segments.length; i++) {
+    const keepGoing = i !== segments.length - 1;
+
+    const byte = (keepGoing ? 128 : 0) + Number(segments[i]);
+    result += byte.toString(16).padStart(2, '0');
+  }
+
+  return result;
+}
+
+export function encodePseudoFloat(xParam: bigint) {
+  let x = xParam;
+
+  if (x === 0n) {
+    return '0x00';
+  }
+
+  let exponent = 0;
+
+  while (x % 10n === 0n && exponent < 30) {
+    x /= 10n;
+    exponent++;
+  }
+
+  const exponentBits = (exponent + 1).toString(2).padStart(5, '0');
+
+  const lowest3Bits = Number(x % 8n)
+    .toString(2)
+    .padStart(3, '0');
+
+  const firstByte = parseInt(`${exponentBits}${lowest3Bits}`, 2)
+    .toString(16)
+    .padStart(2, '0');
+
+  return hexJoin([`0x${firstByte}`, encodeVLQ(x / 8n)]);
+}
+
+export function encodeRegIndex(regIndex: bigint) {
+  const vlqValue = regIndex / 0x010000n;
+  const fixedValue = Number(regIndex / 0x010000n);
+
+  return hexJoin([
+    encodeVLQ(vlqValue),
+    `0x${fixedValue.toString(16).padStart(4, '0')}`,
+  ]);
+}
+
+/**
+ * Bit stacks are just the bits of a uint256 encoded as a VLQ. There is also a
+ * final 1 to indicate the end of the stack.
+ * (Technically the encoding is unbounded, but 256 booleans is a lot and it's
+ * much easier to just decode the VLQ into a uint256 in the EVM.)
+ *
+ * Notably, the bits are little endian - the first bit is the *lowest* bit. This
+ * is because the lowest bit is clearly the 1-valued bit, but the highest valued
+ * bit could be anywhere - there's infinitely many zero-bits to choose from.
+ *
+ * If it wasn't for this need to be little endian, we'd definitely use big
+ * endian (like our other encodings generally do), since that's preferred by the
+ * EVM and the ecosystem:
+ *
+ * ```ts
+ * const abi = new ethers.utils.AbiCoder():
+ * console.log(abi.encode(["uint"], [0xff]));
+ * // 0x00000000000000000000000000000000000000000000000000000000000000ff
+ *
+ * // If Ethereum used little endian (like x86), it would instead be:
+ * // 0xff00000000000000000000000000000000000000000000000000000000000000
+ * ```
+ */
+export function encodeBitStack(bits: boolean[]) {
+  let stack = 1n;
+
+  for (let i = bits.length - 1; i >= 0; i--) {
+    stack <<= 1n;
+    stack += BigInt(bits[i]);
+  }
+
+  const stackVLQ = encodeVLQ(stack);
+
+  return stackVLQ;
+}


### PR DESCRIPTION
# *Dependent PR*

This PR depends on #120, please merge that PR first.

## Description

Resolves #119.

Adds `SafeCompressionAccount` to in-page wallet:

<img width="425" alt="Screen Shot 2023-10-16 at 15 11 25" src="https://github.com/getwax/wax/assets/9291586/6bd3580c-44ba-4de8-a5a5-5d2065a0ea56">

Adds dApp for sending eth:

<img width="285" alt="Screen Shot 2023-10-16 at 15 13 51" src="https://github.com/getwax/wax/assets/9291586/f2ebe2a0-beed-42e0-b40b-33c235227a03">

New logs with prefix `logBytes` for logging about how many bytes are involved in different things:

<img width="630" alt="Screen Shot 2023-10-16 at 15 31 06" src="https://github.com/getwax/wax/assets/9291586/37e51dd5-6d23-4390-9d68-9880b06ed638">

Here we can see that 25 bytes are needed by `decompressAndPerform` to tell it to send 0.1 ETH to the specified address (in future reducible to 8 bytes if the recipient is the in the address registry). Note that this doesn't include specifying the gas limit and other fields of the `userOp`, those are not part of account-level compression and will instead be included in top-level compression (#112).

This still requires 100 bytes of calldata into the account to encode the `decompressAndPerform` call as a whole (4 bytes to specify method, 32 bytes to say where the `stream` argument is, 32 bytes to specify the length of `stream`, 25 bytes for the actual data, and 7 padding bytes). These 75 bytes overhead can be reduced to 1 byte (maybe less) using #112.

Zooming out to the actual EOA transaction (`entryPoint.handleOps`), the transaction requires 952 bytes in total (71% zeros). This will be reduced dramatically later by #112.

For comparison, here are the numbers when doing the same transaction from `SafeECDSAAccount`:

<img width="635" alt="Screen Shot 2023-10-16 at 15 41 12" src="https://github.com/getwax/wax/assets/9291586/b16c11a3-7e7c-4d62-9963-97d84e4e0427">

### Other changes

- Import new contracts (no other/real contract changes)
- New `waxInPage` internal API for getting the account only if it exists
- Change `eth_estimateGas` when `from` is the user's account. By default, the node will estimate the cost of performing that call from that address. This change will instead estimate the entry point making the appropriate call to the user's account to *then* make the specified call.
  - This solves gas issues with compression since it can make a big difference to include the work the account does to decode the action before doing it
  - Also replaces previous logic to add gas when sending eth to a new account
- Implement `eth_getTransactionReceipt` (needed by ethers when sending eth (wasn't needed when sending data for some reason))