### PR TITLE
Fix auth followup / Safe4337Base

### DIFF
--- a/account-integrations/safe/src/SafeBlsPlugin.sol
+++ b/account-integrations/safe/src/SafeBlsPlugin.sol
@@ -4,24 +4,14 @@ pragma abicoder v2;
 
 import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.sol";
 
-import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint, UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {BLS} from "account-abstraction/contracts/samples/bls/lib/hubble-contracts/contracts/libs/BLS.sol";
 
-interface ISafe {
-    function enableModule(address module) external;
-
-    function execTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        uint8 operation
-    ) external returns (bool success);
-}
+import {Safe4337Base, ISafe} from "./utils/Safe4337Base.sol";
 
 error IncorrectSignatureLength(uint256 length);
 
-contract SafeBlsPlugin is BaseAccount, HandlerContext {
+contract SafeBlsPlugin is Safe4337Base {
     // TODO: Use EIP 712 for domain separation
     bytes32 public constant BLS_DOMAIN = keccak256("eip4337.bls.domain");
     address public immutable myAddress;
@@ -30,33 +20,21 @@ contract SafeBlsPlugin is BaseAccount, HandlerContext {
 
     address internal constant _SENTINEL_MODULES = address(0x1);
 
-    error NONCE_NOT_SEQUENTIAL();
-
     constructor(address entryPointAddress, uint256[4] memory blsPublicKey) {
         myAddress = address(this);
         _blsPublicKey = blsPublicKey;
         _entryPoint = entryPointAddress;
     }
 
-    function validateUserOp(
-        UserOperation calldata userOp,
-        bytes32 userOpHash,
-        uint256 missingAccountFunds
-    ) external override returns (uint256 validationData) {
-        _validateNonce(userOp.nonce);
-        validationData = _validateSignature(userOp, userOpHash);
-        _payPrefund(missingAccountFunds);
-    }
-
     function execTransaction(
         address to,
         uint256 value,
         bytes calldata data
-    ) external payable fromThisOrEntryPoint {
-        address payable safeAddress = payable(msg.sender);
-        ISafe safe = ISafe(safeAddress);
+    ) external payable {
+        _requireFromEntryPoint();
+
         require(
-            safe.execTransactionFromModule(to, value, data, 0),
+            _currentSafe().execTransactionFromModule(to, value, data, 0),
             "tx failed"
         );
     }
@@ -95,43 +73,5 @@ contract SafeBlsPlugin is BaseAccount, HandlerContext {
         }
         // TODO: check if wallet recovered
         return SIG_VALIDATION_FAILED;
-    }
-
-    /**
-     * Ensures userOp nonce is sequential. Nonce uniqueness is already managed by the EntryPoint.
-     * This function prevents using a “key” different from the first “zero” key.
-     * @param nonce to validate
-     */
-    function _validateNonce(uint256 nonce) internal pure override {
-        if (nonce >= type(uint64).max) {
-            revert NONCE_NOT_SEQUENTIAL();
-        }
-    }
-
-    /**
-     * This function is overridden as this plugin does not hold funds, so the transaction
-     * has to be executed from the sender Safe
-     * @param missingAccountFunds The minimum value this method should send to the entrypoint
-     */
-    function _payPrefund(uint256 missingAccountFunds) internal override {
-        address payable safeAddress = payable(msg.sender);
-        ISafe senderSafe = ISafe(safeAddress);
-
-        if (missingAccountFunds != 0) {
-            senderSafe.execTransactionFromModule(
-                _entryPoint,
-                missingAccountFunds,
-                "",
-                0
-            );
-        }
-    }
-
-    modifier fromThisOrEntryPoint() {
-        require(
-            _msgSender() == address(this) ||
-            _msgSender() == _entryPoint
-        );
-        _;
     }
 }

--- a/account-integrations/safe/src/SafeCompressionPlugin.sol
+++ b/account-integrations/safe/src/SafeCompressionPlugin.sol
@@ -3,10 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-
 import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.sol";
-
-import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint, UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 import {Safe4337Base, ISafe} from "./utils/Safe4337Base.sol";

--- a/account-integrations/safe/src/SafeCompressionPlugin.sol
+++ b/account-integrations/safe/src/SafeCompressionPlugin.sol
@@ -7,63 +7,42 @@ import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.s
 import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.sol";
 
 import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
-import {UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {IEntryPoint, UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
+import {Safe4337Base, ISafe} from "./utils/Safe4337Base.sol";
 import {WaxLib as W} from "./compression/WaxLib.sol";
 import {IDecompressor} from "./compression/decompressors/IDecompressor.sol";
-
-interface ISafe {
-    function enableModule(address module) external;
-
-    function execTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        uint8 operation
-    ) external returns (bool success);
-}
 
 struct ECDSAOwnerStorage {
     address owner;
 }
 
-contract SafeCompressionPlugin is HandlerContext {
+contract SafeCompressionPlugin is Safe4337Base {
     using ECDSA for bytes32;
-
-    uint256 constant internal SIG_VALIDATION_FAILED = 1;
 
     mapping(address => ECDSAOwnerStorage) public ecdsaOwnerStorage;
     address public immutable myAddress;
-    address private immutable entryPoint;
+    address private immutable _entryPoint;
     IDecompressor public decompressor;
 
     address internal constant _SENTINEL_MODULES = address(0x1);
 
-    error NONCE_NOT_SEQUENTIAL();
     event OWNER_UPDATED(address indexed safe, address indexed oldOwner, address indexed newOwner);
 
     constructor(address entryPointParam, IDecompressor decompressorParam) {
         myAddress = address(this);
-        entryPoint = entryPointParam;
+        _entryPoint = entryPointParam;
         decompressor = decompressorParam;
-    }
-
-    function validateUserOp(
-        UserOperation calldata userOp,
-        bytes32 userOpHash,
-        uint256 missingAccountFunds
-    ) external returns (uint256 validationData) {
-        _validateNonce(userOp.nonce);
-        validationData = _validateSignature(userOp, userOpHash);
-        _payPrefund(missingAccountFunds);
     }
 
     function decompressAndPerform(
         bytes calldata stream
-    ) public fromThisOrEntryPoint {
+    ) public {
+        _requireFromEntryPoint();
+
         (W.Action[] memory actions,) = decompressor.decompress(stream);
 
-        ISafe safe = ISafe(msg.sender);
+        ISafe safe = _currentSafe();
 
         for (uint256 i = 0; i < actions.length; i++) {
             W.Action memory a = actions[i];
@@ -77,7 +56,8 @@ contract SafeCompressionPlugin is HandlerContext {
 
     function setDecompressor(
         IDecompressor decompressorParam
-    ) public fromThisOrEntryPoint {
+    ) public {
+        _requireFromCurrentSafeOrEntryPoint();
         decompressor = decompressorParam;
     }
 
@@ -87,6 +67,10 @@ contract SafeCompressionPlugin is HandlerContext {
         // Enable the safe address with the defined key
         bytes memory _data = abi.encodePacked(ownerKey);
         SafeCompressionPlugin(myAddress).enable(_data);
+    }
+
+    function entryPoint() public view override returns (IEntryPoint) {
+        return IEntryPoint(_entryPoint);
     }
 
     function enable(bytes calldata _data) external payable {
@@ -99,49 +83,14 @@ contract SafeCompressionPlugin is HandlerContext {
     function _validateSignature(
         UserOperation calldata userOp,
         bytes32 userOpHash
-    ) internal view returns (uint256 validationData) {
+    ) internal view override returns (uint256 validationData) {
         address keyOwner = ecdsaOwnerStorage[msg.sender].owner;
         bytes32 hash = userOpHash.toEthSignedMessageHash();
-        if (keyOwner != hash.recover(userOp.signature))
+
+        if (keyOwner != hash.recover(userOp.signature)) {
             return SIG_VALIDATION_FAILED;
+        }
+
         return 0;
-    }
-
-    /**
-     * Ensures userOp nonce is sequential. Nonce uniqueness is already managed by the EntryPoint.
-     * This function prevents using a “key” different from the first “zero” key.
-     * @param nonce to validate
-     */
-    function _validateNonce(uint256 nonce) internal pure {
-        if (nonce >= type(uint64).max) {
-            revert NONCE_NOT_SEQUENTIAL();
-        }
-    }
-
-    /**
-     * This function is overridden as this plugin does not hold funds, so the transaction
-     * has to be executed from the sender Safe
-     * @param missingAccountFunds The minimum value this method should send to the entrypoint
-     */
-    function _payPrefund(uint256 missingAccountFunds) internal {
-        address payable safeAddress = payable(msg.sender);
-        ISafe senderSafe = ISafe(safeAddress);
-
-        if (missingAccountFunds != 0) {
-            senderSafe.execTransactionFromModule(
-                entryPoint,
-                missingAccountFunds,
-                "",
-                0
-            );
-        }
-    }
-
-    modifier fromThisOrEntryPoint() {
-        require(
-            _msgSender() == entryPoint ||
-            _msgSender() == address(this)
-        );
-        _;
     }
 }

--- a/account-integrations/safe/src/SafeWebAuthnPlugin.sol
+++ b/account-integrations/safe/src/SafeWebAuthnPlugin.sol
@@ -2,10 +2,11 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.sol";
-
 import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint, UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {WebAuthn} from "wax/primitives/src/WebAuthn.sol";
+
+import {Safe4337Base} from "./utils/Safe4337Base.sol";
 
 interface ISafe {
     function enableModule(address module) external;
@@ -18,14 +19,12 @@ interface ISafe {
     ) external returns (bool success);
 }
 
-contract SafeWebAuthnPlugin is BaseAccount, WebAuthn, HandlerContext {
+contract SafeWebAuthnPlugin is Safe4337Base, WebAuthn {
     address public immutable myAddress;
     address private immutable _entryPoint;
     uint256[2] private _publicKey;
 
     address internal constant _SENTINEL_MODULES = address(0x1);
-
-    error NONCE_NOT_SEQUENTIAL();
 
     constructor(address entryPointAddress, uint256[2] memory pubKey) {
         myAddress = address(this);
@@ -33,25 +32,15 @@ contract SafeWebAuthnPlugin is BaseAccount, WebAuthn, HandlerContext {
         _publicKey = pubKey;
     }
 
-    function validateUserOp(
-        UserOperation calldata userOp,
-        bytes32 userOpHash,
-        uint256 missingAccountFunds
-    ) external override returns (uint256 validationData) {
-        _validateNonce(userOp.nonce);
-        validationData = _validateSignature(userOp, userOpHash);
-        _payPrefund(missingAccountFunds);
-    }
-
     function execTransaction(
         address to,
         uint256 value,
         bytes calldata data
-    ) external payable fromThisOrEntryPoint {
-        address payable safeAddress = payable(msg.sender);
-        ISafe safe = ISafe(safeAddress);
+    ) external payable {
+        _requireFromEntryPoint();
+
         require(
-            safe.execTransactionFromModule(to, value, data, 0),
+            _currentSafe().execTransactionFromModule(to, value, data, 0),
             "tx failed"
         );
     }
@@ -78,7 +67,7 @@ contract SafeWebAuthnPlugin is BaseAccount, WebAuthn, HandlerContext {
 
     function _validateSignature(
         UserOperation calldata userOp,
-        bytes32 userOpHash
+        bytes32 /*userOpHash*/
     ) internal override returns (uint256 validationData) {
         bytes calldata authenticatorData;
         bytes calldata clientData;
@@ -160,43 +149,5 @@ contract SafeWebAuthnPlugin is BaseAccount, WebAuthn, HandlerContext {
         );
         if (!verified) return SIG_VALIDATION_FAILED;
         return 0;
-    }
-
-    /**
-     * Ensures userOp nonce is sequential. Nonce uniqueness is already managed by the EntryPoint.
-     * This function prevents using a “key” different from the first “zero” key.
-     * @param nonce to validate
-     */
-    function _validateNonce(uint256 nonce) internal view override {
-        if (nonce >= type(uint64).max) {
-            revert NONCE_NOT_SEQUENTIAL();
-        }
-    }
-
-    /**
-     * This function is overridden as this plugin does not hold funds, so the transaction
-     * has to be executed from the sender Safe
-     * @param missingAccountFunds The minimum value this method should send to the entrypoint
-     */
-    function _payPrefund(uint256 missingAccountFunds) internal override {
-        address payable safeAddress = payable(msg.sender);
-        ISafe senderSafe = ISafe(safeAddress);
-
-        if (missingAccountFunds != 0) {
-            senderSafe.execTransactionFromModule(
-                _entryPoint,
-                missingAccountFunds,
-                "",
-                0
-            );
-        }
-    }
-
-    modifier fromThisOrEntryPoint() {
-        require(
-            _msgSender() == address(this) ||
-            _msgSender() == _entryPoint
-        );
-        _;
     }
 }

--- a/account-integrations/safe/src/utils/Safe4337Base.sol
+++ b/account-integrations/safe/src/utils/Safe4337Base.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.sol";
+
+import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
+
+interface ISafe {
+    function enableModule(address module) external;
+
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint8 operation
+    ) external returns (bool success);
+}
+
+/**
+ * Base contract with common code for implementing a 4337 plugin for a Safe.
+ *
+ * In particular, this modifies eth-infinitism's BaseAccount to use
+ * `_msgSender()` when checking the call comes from the entry point, and pays
+ * the prefund using `execTransactionFromModule`.
+ */
+abstract contract Safe4337Base is BaseAccount, HandlerContext {
+    error NONCE_NOT_SEQUENTIAL();
+
+    /**
+     * ensure the request comes from the known entrypoint.
+     */
+    function _requireFromEntryPoint() internal virtual view override {
+        require(
+            _msgSender() == address(entryPoint()),
+            "account: not from EntryPoint"
+        );
+    }
+
+    /**
+     * This function is overridden as this plugin does not hold funds, so the
+     * transaction has to be executed from the sender Safe
+     * @param missingAccountFunds The minimum value this method should send to
+     *   the entrypoint
+     */
+    function _payPrefund(
+        uint256 missingAccountFunds
+    ) internal virtual override {
+        if (missingAccountFunds != 0) {
+            _thisSafe().execTransactionFromModule(
+                address(entryPoint()),
+                missingAccountFunds,
+                "",
+                0
+            );
+        }
+    }
+
+    /**
+     * Ensures userOp nonce is sequential. Nonce uniqueness is already managed
+     * by the EntryPoint. This function prevents using a “key” different from
+     * the first “zero” key.
+     * @param nonce to validate
+     */
+    function _validateNonce(uint256 nonce) internal pure override {
+        if (nonce >= type(uint64).max) {
+            revert NONCE_NOT_SEQUENTIAL();
+        }
+    }
+
+    function _thisSafe() internal virtual view returns (ISafe) {
+        // There is some confusion about whether `msg.sender` should be used
+        // instead of `this` for referring to the current Safe. There is a PR
+        // here to get feedback from Safe about this:
+        //   https://github.com/safe-global/safe-contracts/pull/682
+        return ISafe(address(this));
+    }
+}

--- a/account-integrations/safe/src/utils/Safe4337Base.sol
+++ b/account-integrations/safe/src/utils/Safe4337Base.sol
@@ -34,6 +34,14 @@ abstract contract Safe4337Base is BaseAccount, HandlerContext {
         );
     }
 
+    function _requireFromCurrentSafeOrEntryPoint() internal virtual view {
+        require(
+            _msgSender() == address(entryPoint()) ||
+            _msgSender() == address(_currentSafe()),
+            "account: not from EntryPoint"
+        );
+    }
+
     /**
      * This function is overridden as this plugin does not hold funds, so the
      * transaction has to be executed from the sender Safe

--- a/account-integrations/safe/test/forge/SafeBlsPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeBlsPlugin.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console2.sol";
 import {TestHelper} from "./utils/TestHelper.sol";
 import {SafeBlsPluginHarness} from "./utils/SafeBlsPluginHarness.sol";
 import {SafeBlsPlugin} from "../../src/SafeBlsPlugin.sol";
+import {Safe4337Base} from "../../src/utils/Safe4337Base.sol";
 import {UserOperation, UserOperationLib} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 /* solhint-disable func-name-mixedcase */
@@ -44,7 +45,7 @@ contract SafeBlsPluginTest is TestHelper {
         uint256 nonce = type(uint64).max;
 
         // Act & Assert
-        vm.expectRevert(SafeBlsPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeBlsPlugin.exposed_validateNonce(nonce);
     }
 
@@ -53,7 +54,7 @@ contract SafeBlsPluginTest is TestHelper {
         uint256 nonce = uint256(type(uint64).max) + 1;
 
         // Act & Assert
-        vm.expectRevert(SafeBlsPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeBlsPlugin.exposed_validateNonce(nonce);
     }
 }

--- a/account-integrations/safe/test/forge/SafeECDSAPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeECDSAPlugin.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console2.sol";
 import {TestHelper} from "./utils/TestHelper.sol";
 import {SafeECDSAPluginHarness} from "./utils/SafeECDSAPluginHarness.sol";
 import {SafeECDSAPlugin} from "../../src/SafeECDSAPlugin.sol";
+import {Safe4337Base} from "../../src/utils/Safe4337Base.sol";
 import {UserOperation, UserOperationLib} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 /* solhint-disable func-name-mixedcase */
@@ -40,7 +41,7 @@ contract SafeECDSAPluginTest is TestHelper {
         uint256 nonce = type(uint64).max;
 
         // Act & Assert
-        vm.expectRevert(SafeECDSAPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeECDSAPlugin.exposedValidateNonce(nonce);
     }
 
@@ -49,7 +50,7 @@ contract SafeECDSAPluginTest is TestHelper {
         uint256 nonce = uint256(type(uint64).max) + 1;
 
         // Act & Assert
-        vm.expectRevert(SafeECDSAPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeECDSAPlugin.exposedValidateNonce(nonce);
     }
 }

--- a/account-integrations/safe/test/forge/SafeWebAuthnPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeWebAuthnPlugin.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console2.sol";
 import {TestHelper} from "./utils/TestHelper.sol";
 import {SafeWebAuthnPluginHarness} from "./utils/SafeWebAuthnPluginHarness.sol";
 import {SafeWebAuthnPlugin} from "../../src/SafeWebAuthnPlugin.sol";
+import {Safe4337Base} from "../../src/utils/Safe4337Base.sol";
 import {UserOperation, UserOperationLib} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 /* solhint-disable func-name-mixedcase */
@@ -101,7 +102,7 @@ contract SafeWebAuthnPluginTest is TestHelper {
         uint256 nonce = type(uint64).max;
 
         // Act & Assert
-        vm.expectRevert(SafeWebAuthnPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeWebAuthnPlugin.exposed_validateNonce(nonce);
     }
 
@@ -110,7 +111,7 @@ contract SafeWebAuthnPluginTest is TestHelper {
         uint256 nonce = uint256(type(uint64).max) + 1;
 
         // Act & Assert
-        vm.expectRevert(SafeWebAuthnPlugin.NONCE_NOT_SEQUENTIAL.selector);
+        vm.expectRevert(Safe4337Base.NONCE_NOT_SEQUENTIAL.selector);
         safeWebAuthnPlugin.exposed_validateNonce(nonce);
     }
 }


### PR DESCRIPTION
# *Dependent PR*

This PR depends on #120, please merge that PR first.

## Description

Followup for #118.

Changes:
- Override `_requireFromEntryPoint()` to use `_msgSender()` (comment)
  - Allows removal of `validateUserOp` overrides because the `BaseAccount` version now does the correct thing
- Prefer only allowing calls from entry point (comment)
- Implements the above as a common base class `Safe4337Base` which also allows deduplicating:
  - `_payPrefund()`
  - `_validateNonce()`
- `Safe4337Base` also implements `_currentSafe()` which helps clear up confusion for referring to the safe