### PR TITLE
Allow passing a default deployer seed phrase

### DIFF
--- a/demos/inpage/.gitignore
+++ b/demos/inpage/.gitignore
@@ -1,4 +1,4 @@
-demo/config.ts
+demo/config/config.ts
 
 # Logs
 logs

--- a/demos/inpage/demo/DemoContext.ts
+++ b/demos/inpage/demo/DemoContext.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import WaxInPage, { Contracts, EthereumApi } from '../src';
 import TypedEmitter from './helpers/TypedEmitter';
 import runAsync from './helpers/runAsync';
+import config from './config/config';
 
 type BalanceUpdate = { address: string; balance: bigint };
 
@@ -20,6 +21,7 @@ export default class DemoContext {
 
   constructor(public waxInPage: WaxInPage) {
     this.ethereum = waxInPage.ethereum;
+    waxInPage.setDeployerSeedPhrase(config.deployerSeedPhrase);
 
     runAsync(async () => {
       const accounts = await this.ethereum.request({

--- a/demos/inpage/demo/config/ConfigType.ts
+++ b/demos/inpage/demo/config/ConfigType.ts
@@ -4,6 +4,7 @@ type ConfigType = {
   bundlerRpcUrl?: string;
   pollingInterval?: number;
   addFundsEthAmount?: string;
+  deployerSeedPhrase: string;
 };
 
 export default ConfigType;

--- a/demos/inpage/demo/config/config.template.ts
+++ b/demos/inpage/demo/config/config.template.ts
@@ -12,7 +12,8 @@ import ConfigType from './ConfigType';
 const config: ConfigType = {
   logRequests: true,
   rpcUrl: 'http://127.0.0.1:8545',
-
+  deployerSeedPhrase:
+    'test test test test test test test test test test test junk',
   // Uncomment this with the url of a bundler to enable using an external
   // bundler (sometimes this is the same as rpcUrl). Otherwise, a bundler will
   // be simulated inside the library.

--- a/demos/inpage/demo/config/config.testnet.ts
+++ b/demos/inpage/demo/config/config.testnet.ts
@@ -16,7 +16,7 @@ const config: ConfigType = {
     'https://sepolia-rollup.arbitrum.io/rpc',
 
   // If a default seed phrase is not provided, a user must provide their own.
-  deployerSeedPhrase: (import.meta.env.VITE_RPC_URL as string) ?? '',
+  deployerSeedPhrase: (import.meta.env.DEPLOYER_SEED_PHRASE as string) ?? '',
 
   // Uncomment this with the url of a bundler to enable using an external
   // bundler (sometimes this is the same as rpcUrl). Otherwise, a bundler will

--- a/demos/inpage/demo/config/config.testnet.ts
+++ b/demos/inpage/demo/config/config.testnet.ts
@@ -15,6 +15,9 @@ const config: ConfigType = {
     (import.meta.env.VITE_RPC_URL as string) ??
     'https://sepolia-rollup.arbitrum.io/rpc',
 
+  // If a default seed phrase is not provided, a user must provide their own.
+  deployerSeedPhrase: (import.meta.env.VITE_RPC_URL as string) ?? '',
+
   // Uncomment this with the url of a bundler to enable using an external
   // bundler (sometimes this is the same as rpcUrl). Otherwise, a bundler will
   // be simulated inside the library.

--- a/demos/inpage/src/AdminPopup.tsx
+++ b/demos/inpage/src/AdminPopup.tsx
@@ -71,12 +71,14 @@ const AdminPopup = ({
   purpose,
   resolve,
   reject,
+  deployerSeedPhrase,
 }: {
   purpose: AdminPurpose;
   resolve: (response: string) => void;
   reject: (error: Error) => void;
+  deployerSeedPhrase: string;
 }) => {
-  const [keyData, setKeyData] = useState(`${'test '.repeat(11)}junk`);
+  const [keyData, setKeyData] = useState(deployerSeedPhrase);
 
   let message = 'Invalid';
 

--- a/demos/inpage/src/WaxInPage.tsx
+++ b/demos/inpage/src/WaxInPage.tsx
@@ -71,6 +71,7 @@ export default class WaxInPage {
   ethereum: EthereumApi;
   storage: WaxStorage;
   ethersProvider: ethers.BrowserProvider;
+  deployerSeedPhrase = '';
 
   constructor({
     rpcUrl,
@@ -148,6 +149,10 @@ export default class WaxInPage {
     popup.close();
 
     return response;
+  }
+
+  setDeployerSeedPhrase(seed: string) {
+    this.deployerSeedPhrase = seed;
   }
 
   async getContracts(
@@ -241,7 +246,12 @@ export default class WaxInPage {
           popup.getWindow().document.getElementById('root')!,
         ).render(
           <React.StrictMode>
-            <AdminPopup purpose={purpose} resolve={resolve} reject={reject} />
+            <AdminPopup
+              purpose={purpose}
+              resolve={resolve}
+              reject={reject}
+              deployerSeedPhrase={this.deployerSeedPhrase}
+            />
           </React.StrictMode>,
         );
 


### PR DESCRIPTION
Right now when loading [the deployed demo](https://main.d2q4o4f8gnoq5j.amplifyapp.com/) the user needs to put in a funded wallet so the contracts can be deployed.  This change allows us to see a default deployer wallet that we can fund.  This will make the UX a little more streamlined for dev connect.  I also use an ENV variable so we don't have to commit the seed phrase.

For more context see this convo: https://github.com/getwax/wax/pull/114#issuecomment-1759471539