### PR TITLE
Update recovery plugin to be singleton

### DIFF
--- a/account-integrations/safe/foundry.toml
+++ b/account-integrations/safe/foundry.toml
@@ -1,8 +1,13 @@
 [profile.default]
 src = "src"
 out = "out"
-libs = ["lib"]
+libs = [
+    "lib",
+]
 
-allow_paths = ["../../primitives"]
+allow_paths = [
+    "../../primitives",
+    "src/compression",
+]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/account-integrations/safe/src/SafeECDSAPlugin.sol
+++ b/account-integrations/safe/src/SafeECDSAPlugin.sol
@@ -33,11 +33,19 @@ contract SafeECDSAPlugin is Safe4337Base {
 
     address internal constant _SENTINEL_MODULES = address(0x1);
 
-    event OWNER_UPDATED(address indexed safe, address indexed oldOwner, address indexed newOwner);
+    event OWNER_UPDATED(
+        address indexed safe,
+        address indexed oldOwner,
+        address indexed newOwner
+    );
 
     constructor(address entryPointAddress) {
         myAddress = address(this);
         _entryPoint = entryPointAddress;
+    }
+
+    function getOwner(address safe) external view returns (address owner) {
+        owner = ecdsaOwnerStorage[safe].owner;
     }
 
     function execTransaction(

--- a/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
@@ -44,6 +44,12 @@ contract SafeECDSARecoveryPlugin {
 
     constructor() {}
 
+    function getEcdsaRecoveryStorage(
+        address owner
+    ) external view returns (ECDSARecoveryStorage memory) {
+        return ecdsaRecoveryStorage[owner];
+    }
+
     modifier onlyRecoveryAccount(address currentOwner) {
         address recoveryAccount = ecdsaRecoveryStorage[currentOwner]
             .recoveryAccount;

--- a/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
@@ -56,18 +56,18 @@ contract SafeECDSARecoveryPlugin {
     // TODO: (merge-ok) prove recovery address owner possesses private key and proof cannot be replayed
     function addRecoveryAccount(
         address recoveryAccount,
-        address safeAddr,
+        address safe,
         address ecsdaPlugin
     ) external {
-        if (safeAddr == address(0)) revert SAFE_ZERO_ADDRESS();
+        if (safe == address(0)) revert SAFE_ZERO_ADDRESS();
 
-        address owner = ISafeECDSAPlugin(ecsdaPlugin).getOwner(safeAddr);
+        address owner = ISafeECDSAPlugin(ecsdaPlugin).getOwner(safe);
         if (msg.sender != owner)
             revert MSG_SENDER_NOT_PLUGIN_OWNER(msg.sender, owner);
 
         ecdsaRecoveryStorage[msg.sender] = ECDSARecoveryStorage(
             recoveryAccount,
-            safeAddr
+            safe
         );
     }
 

--- a/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import {TestHelper} from "./utils/TestHelper.sol";
+import {SafeECDSARecoveryPlugin, ECDSARecoveryStorage} from "../../src/SafeECDSARecoveryPlugin.sol";
+import {SafeECDSAPlugin} from "../../src/SafeECDSAPlugin.sol";
+import {Safe} from "safe-contracts/contracts/Safe.sol";
+import {SafeProxy} from "safe-contracts/contracts/proxies/SafeProxy.sol";
+
+/* solhint-disable func-name-mixedcase */
+
+contract SafeECDSARecoveryPluginTest is TestHelper {
+    constructor() TestHelper() {}
+
+    SafeECDSARecoveryPlugin public safeECDSARecoveryPlugin;
+    SafeECDSAPlugin public safeECDSAPlugin;
+    Safe public safe;
+    address public safeAddress;
+
+    address owner = ALICE;
+
+    function setUp() public {
+        safeECDSARecoveryPlugin = new SafeECDSARecoveryPlugin();
+        safeECDSAPlugin = new SafeECDSAPlugin(entryPointAddress);
+
+        Safe safeSingleton = new Safe();
+        SafeProxy safeProxy = new SafeProxy(address(safeSingleton));
+
+        address[] memory owners = new address[](1);
+        owners[0] = owner;
+
+        safe = Safe(payable(address(safeProxy)));
+        safeAddress = address(safe);
+
+        safe.setup(
+            owners,
+            1,
+            address(safeECDSAPlugin),
+            abi.encodeCall(SafeECDSAPlugin.enableMyself, (owner)),
+            address(safeECDSAPlugin),
+            address(0),
+            0,
+            payable(address(0))
+        );
+    }
+
+    function test_addRecoveryAccount_SafeZeroAddress() public {
+        // Arrange
+        address recoveryAccount = BOB;
+        address safeZeroAddress = address(0);
+
+        // Act & Assert
+        vm.expectRevert(SafeECDSARecoveryPlugin.SAFE_ZERO_ADDRESS.selector);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount,
+            safeZeroAddress,
+            address(safeECDSAPlugin)
+        );
+    }
+
+    function test_addRecoveryAccount_MsgSenderNotPluginOwner() public {
+        // Arrange
+        address recoveryAccount = BOB;
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeECDSARecoveryPlugin.MSG_SENDER_NOT_PLUGIN_OWNER.selector,
+                recoveryAccount,
+                owner
+            )
+        );
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+    }
+
+    function test_addRecoveryAccount_recoveryAccountAdded() public {
+        // Arrange
+        address recoveryAccount = BOB;
+
+        // Act
+        vm.startPrank(owner);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+
+        ECDSARecoveryStorage
+            memory ecdsaRecoveryStorage = safeECDSARecoveryPlugin
+                .getEcdsaRecoveryStorage(owner);
+
+        // Assert
+        assertEq(ecdsaRecoveryStorage.recoveryAccount, recoveryAccount);
+        assertEq(ecdsaRecoveryStorage.safe, safeAddress);
+    }
+
+    function test_resetEcdsaAddress_senderNotRecoveryAccount() public {
+        // Arrange
+        address newOwner = BOB;
+        address recoveryAccount = CAROL;
+        address expectedRecoveryAccount = address(0);
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeECDSARecoveryPlugin.SENDER_NOT_RECOVERY_ACCOUNT.selector,
+                recoveryAccount,
+                expectedRecoveryAccount
+            )
+        );
+        safeECDSARecoveryPlugin.resetEcdsaAddress(
+            safeAddress,
+            address(safeECDSAPlugin),
+            owner,
+            newOwner
+        );
+    }
+
+    function test_resetEcdsaAddress_attemptingResetOnWrongSafe() public {
+        // Arrange
+        address recoveryAccount = BOB;
+        address newOwner = CAROL;
+        address wrongSafeAddress = DAVE;
+
+        vm.startPrank(safeAddress);
+        safe.enableModule(address(safeECDSARecoveryPlugin));
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+        vm.stopPrank();
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeECDSARecoveryPlugin.ATTEMPTING_RESET_ON_WRONG_SAFE.selector,
+                wrongSafeAddress,
+                safeAddress
+            )
+        );
+        safeECDSARecoveryPlugin.resetEcdsaAddress(
+            wrongSafeAddress,
+            address(safeECDSAPlugin),
+            owner,
+            newOwner
+        );
+    }
+
+    function test_resetEcdsaAddress_resetsEcdsaAddress() public {
+        // Arrange
+        address recoveryAccount = BOB;
+        address newOwner = CAROL;
+
+        vm.startPrank(safeAddress);
+        safe.enableModule(address(safeECDSARecoveryPlugin));
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+        vm.stopPrank();
+
+        // Act
+        vm.startPrank(recoveryAccount);
+        safeECDSARecoveryPlugin.resetEcdsaAddress(
+            safeAddress,
+            address(safeECDSAPlugin),
+            owner,
+            newOwner
+        );
+
+        // Assert
+        address updatedOwner = safeECDSAPlugin.getOwner(safeAddress);
+        assertEq(updatedOwner, newOwner);
+    }
+}

--- a/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
@@ -101,6 +101,53 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         assertEq(ecdsaRecoveryStorage.safe, safeAddress);
     }
 
+    function test_addRecoveryAccount_addMultipleRecoveryAccountsAndPlugins()
+        public
+    {
+        // Arrange
+        address recoveryAccount1 = BOB;
+        address recoveryAccount2 = CAROL;
+        address secondOwner = DAVE;
+
+        SafeECDSAPlugin secondSafeECDSAPlugin = new SafeECDSAPlugin(
+            entryPointAddress
+        );
+
+        vm.startPrank(safeAddress);
+        secondSafeECDSAPlugin.enable(abi.encodePacked(secondOwner));
+        vm.stopPrank();
+
+        // Act
+        vm.startPrank(owner);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount1,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+
+        vm.startPrank(secondOwner);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryAccount2,
+            safeAddress,
+            address(secondSafeECDSAPlugin)
+        );
+
+        // Assert
+        ECDSARecoveryStorage
+            memory ecdsaRecoveryStorage = safeECDSARecoveryPlugin
+                .getEcdsaRecoveryStorage(owner);
+
+        ECDSARecoveryStorage
+            memory ecdsaRecoveryStorage2 = safeECDSARecoveryPlugin
+                .getEcdsaRecoveryStorage(secondOwner);
+
+        assertEq(ecdsaRecoveryStorage.recoveryAccount, recoveryAccount1);
+        assertEq(ecdsaRecoveryStorage.safe, safeAddress);
+
+        assertEq(ecdsaRecoveryStorage2.recoveryAccount, recoveryAccount2);
+        assertEq(ecdsaRecoveryStorage2.safe, safeAddress);
+    }
+
     function test_resetEcdsaAddress_senderNotRecoveryAccount() public {
         // Arrange
         address newOwner = BOB;

--- a/account-integrations/safe/test/forge/utils/TestHelper.sol
+++ b/account-integrations/safe/test/forge/utils/TestHelper.sol
@@ -10,9 +10,11 @@ abstract contract TestHelper is Test {
     EntryPoint public entryPoint;
     address internal entryPointAddress;
 
-    address internal constant ALICE = address(1);
-    address internal constant BOB = address(2);
-    address[] internal testAccounts = [ALICE, BOB];
+    address internal constant ALICE = address(2); // don't start at 1 as clashes with safe contracts sentinel address
+    address internal constant BOB = address(3);
+    address internal constant CAROL = address(4);
+    address internal constant DAVE = address(5);
+    address[] internal testAccounts = [ALICE, BOB, CAROL, DAVE];
 
     constructor() {
         entryPoint = new EntryPoint();

--- a/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
@@ -37,7 +37,7 @@ describe("SafeECDSARecoveryPlugin", () => {
 
     const recoveryPlugin = await (
       await ethers.getContractFactory("SafeECDSARecoveryPlugin")
-    ).deploy(safeCounterfactualAddress, recoverySigner.address);
+    ).deploy();
     const recoveryPluginAddress = await recoveryPlugin.getAddress();
 
     // Enable recovery plugin on safe
@@ -74,7 +74,7 @@ describe("SafeECDSARecoveryPlugin", () => {
 
     const recoveryPlugin = await (
       await ethers.getContractFactory("SafeECDSARecoveryPlugin")
-    ).deploy(safeCounterfactualAddress, recoverySigner.address);
+    ).deploy();
     const recoveryPluginAddress = await recoveryPlugin.getAddress();
 
     const deployedSafe = await ethers.getContractAt(
@@ -98,18 +98,30 @@ describe("SafeECDSARecoveryPlugin", () => {
     );
     expect(isModuleEnabled).to.equal(true);
 
-    // Reset ecdsa address
+    // Add recovery account
 
     const ecdsaPluginAddress = await safeECDSAPlugin.getAddress();
+
+    await recoveryPlugin
+      .connect(safeSigner)
+      .addRecoveryAccount(
+        recoverySigner.address,
+        safeCounterfactualAddress,
+        ecdsaPluginAddress,
+      );
+
+    // Reset ecdsa address
+
     const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
 
-    const recoveryPluginSinger = recoveryPlugin.connect(recoverySigner);
-
-    await recoveryPluginSinger.resetEcdsaAddress(
-      await deployedSafe.getAddress(),
-      ecdsaPluginAddress,
-      newEcdsaPluginSigner.address,
-    );
+    await recoveryPlugin
+      .connect(recoverySigner)
+      .resetEcdsaAddress(
+        await deployedSafe.getAddress(),
+        ecdsaPluginAddress,
+        safeSigner.address,
+        newEcdsaPluginSigner.address,
+      );
 
     // Send tx with new key
 

--- a/demos/inpage/demo/Recovery.tsx
+++ b/demos/inpage/demo/Recovery.tsx
@@ -16,9 +16,8 @@ const Recovery = () => {
   const account = demo.useAccount();
 
   const [recoveryAddress, setRecoveryAddress] = useState('');
-  const [newOwnerAccountSeedPhrase, setNewOwnerAccountSeedPhrase] =
-    useState('');
-  const [recoveryAccountSeedPhrase, setRecoveryAccountSeedPhrase] =
+  const [newOwnerPrivateKey, setNewOwnerPrivateKey] = useState('');
+  const [recoveryAccountPrivateKey, setRecoveryAccountPrivateKey] =
     useState('');
 
   if (!contracts) {
@@ -86,20 +85,18 @@ const Recovery = () => {
         <section className="recovery-section">
           <Heading>Recover account</Heading>
           <div>
-            New owner account seed phrase:{' '}
+            New owner account private key:{' '}
             <input
               type="text"
-              onInput={(e) =>
-                setNewOwnerAccountSeedPhrase(e.currentTarget.value)
-              }
+              onInput={(e) => setNewOwnerPrivateKey(e.currentTarget.value)}
             />
           </div>
           <div>
-            Recovery account seed phrase:{' '}
+            Recovery account private key:{' '}
             <input
               type="text"
               onInput={(e) =>
-                setRecoveryAccountSeedPhrase(e.currentTarget.value)
+                setRecoveryAccountPrivateKey(e.currentTarget.value)
               }
             />
           </div>
@@ -108,9 +105,9 @@ const Recovery = () => {
             onPress={async () => {
               if (account instanceof SafeECDSAAccountWrapper) {
                 // TODO: (merge-ok) Handle recovery without passing seed phrases
-                await account.recoveryAccount(
-                  newOwnerAccountSeedPhrase,
-                  recoveryAccountSeedPhrase,
+                await account.recoverAccount(
+                  newOwnerPrivateKey,
+                  recoveryAccountPrivateKey,
                 );
               }
 

--- a/demos/inpage/hardhat/hardhat.config.ts
+++ b/demos/inpage/hardhat/hardhat.config.ts
@@ -1,4 +1,4 @@
-import { HardhatUserConfig } from 'hardhat/config';
+import { HardhatUserConfig, task, types } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
@@ -16,5 +16,26 @@ const config: HardhatUserConfig = {
     ],
   },
 };
+
+task('sendEth', 'Sends ETH to an address')
+  .addParam('address', 'Address to send ETH to', undefined, types.string)
+  .addOptionalParam('amount', 'Amount of ETH to send', '1.0')
+  .setAction(
+    async ({ address, amount }: { address: string; amount: string }, hre) => {
+      const wallet = hre.ethers.Wallet.fromPhrase(
+        `${'test '.repeat(11)}junk`,
+        hre.ethers.provider,
+      );
+
+      console.log(`${wallet.address} -> ${address} ${amount} ETH`);
+
+      const txnRes = await wallet.sendTransaction({
+        to: address,
+        value: hre.ethers.parseEther(amount),
+      });
+
+      await txnRes.wait();
+    },
+  );
 
 export default config;

--- a/demos/inpage/src/WaxInPage.tsx
+++ b/demos/inpage/src/WaxInPage.tsx
@@ -20,6 +20,8 @@ import {
   SafeCompressionFactory__factory,
   SafeECDSAFactory,
   SafeECDSAFactory__factory,
+  SafeECDSARecoveryPlugin,
+  SafeECDSARecoveryPlugin__factory,
   Safe__factory,
   SimpleAccountFactory,
   SimpleAccountFactory__factory,
@@ -72,6 +74,7 @@ export type Contracts = {
   safeCompressionFactory: SafeCompressionFactory;
   fallbackDecompressor: FallbackDecompressor;
   addressRegistry: AddressRegistry;
+  safeECDSARecoveryPlugin: SafeECDSARecoveryPlugin;
 };
 
 export default class WaxInPage {
@@ -201,6 +204,10 @@ export default class WaxInPage {
         [await assumedAddressRegistry.getAddress()],
       ),
       addressRegistry: assumedAddressRegistry,
+      safeECDSARecoveryPlugin: viewer.connectAssume(
+        SafeECDSARecoveryPlugin__factory,
+        [],
+      ),
     };
 
     if (this.#contractsDeployed) {
@@ -246,6 +253,8 @@ export default class WaxInPage {
           await addressRegistry.getAddress(),
         ]),
       addressRegistry: () => Promise.resolve(addressRegistry),
+      safeECDSARecoveryPlugin: () =>
+        factory.connectOrDeploy(SafeECDSARecoveryPlugin__factory, []),
     };
 
     for (const deployment of Object.values(deployments)) {

--- a/demos/inpage/src/accounts/SafeECDSAAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeECDSAAccountWrapper.ts
@@ -193,21 +193,18 @@ export default class SafeECDSAAccountWrapper implements IAccount {
     await this.waxInPage.storage.accounts.set([this.toData()]);
   }
 
-  async recoveryAccount(
-    newOwnerAccountSeedPhrase: string,
-    recoveryAddressSeedPhrase: string,
+  async recoverAccount(
+    newOwnerPrivateKey: string,
+    recoveryAccountPrivateKey: string,
   ) {
     const provider = this.waxInPage.ethersProvider;
     const owner = new ethers.Wallet(this.privateKey, provider);
 
-    const newOwnerWallet = ethers.Wallet.fromPhrase(
-      newOwnerAccountSeedPhrase,
-      provider,
-    );
+    const newOwnerWallet = new ethers.Wallet(newOwnerPrivateKey, provider);
     const newOwnerAddress = newOwnerWallet.address;
 
-    const recoveryWallet = ethers.Wallet.fromPhrase(
-      recoveryAddressSeedPhrase,
+    const recoveryWallet = new ethers.Wallet(
+      recoveryAccountPrivateKey,
       provider,
     );
 
@@ -216,14 +213,6 @@ export default class SafeECDSAAccountWrapper implements IAccount {
     const recoveryPlugin = contracts.safeECDSARecoveryPlugin;
 
     const ecdsaPlugin = this.getContract();
-
-    // TODO: (merge-ok) ensure wallet is already funded
-    await (
-      await owner.sendTransaction({
-        to: recoveryWallet.address,
-        value: ethers.parseEther('0.1'),
-      })
-    ).wait();
 
     const pluginAddress = await ecdsaPlugin.myAddress();
     await recoveryPlugin


### PR DESCRIPTION
This PR:
1. Updates `SafeECDSARecoveryPlugin` so that it can be used by multiple accounts and is not tightly coupled to a single `SafeECDSAPlugin`.
2. Updates inpage demo to use updated contracts
3. Updates inpage demo to take private keys instead of seed phrases. Private keys are easier to source when running the demo (when using funded hardhat accounts), compared to seed phrases where you have the extra step of funding them first. This change is just to make running through the demo easier as we can use the logged hardhat accounts. The idea is to remove the need to pass private keys or seed phrases in at all, so this is a temporary solution anyway
4. Adds a hardhat task for funding accounts
5. Adds forge tests for new contract changes