### PR TITLE
131 recover account via signature

### DIFF
--- a/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
@@ -29,7 +29,7 @@ interface ISafeECDSAPlugin {
 }
 
 struct ECDSARecoveryStorage {
-    bytes32 guardianHash;
+    bytes32 recoveryHash;
     address safe;
 }
 
@@ -43,7 +43,7 @@ contract SafeECDSARecoveryPlugin {
     mapping(address => ECDSARecoveryStorage) public ecdsaRecoveryStorage;
 
     error INVALID_GUARDIAN_HASH(
-        bytes32 guardianHash,
+        bytes32 recoveryHash,
         bytes32 expectedGuardianHash
     );
     error SAFE_ZERO_ADDRESS();
@@ -72,7 +72,7 @@ contract SafeECDSARecoveryPlugin {
     }
 
     function addRecoveryAccount(
-        bytes32 guardianHash,
+        bytes32 recoveryHash,
         address safe,
         address ecsdaPlugin
     ) external {
@@ -83,7 +83,7 @@ contract SafeECDSARecoveryPlugin {
             revert MSG_SENDER_NOT_PLUGIN_OWNER(msg.sender, owner);
 
         ecdsaRecoveryStorage[msg.sender] = ECDSARecoveryStorage(
-            guardianHash,
+            recoveryHash,
             safe
         );
     }
@@ -110,9 +110,9 @@ contract SafeECDSARecoveryPlugin {
             )
         );
 
-        if (expectedRecoveryHash != recoveryStorage.guardianHash) {
+        if (expectedRecoveryHash != recoveryStorage.recoveryHash) {
             revert INVALID_GUARDIAN_HASH(
-                recoveryStorage.guardianHash,
+                recoveryStorage.recoveryHash,
                 expectedRecoveryHash
             );
         }

--- a/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol
@@ -22,6 +22,8 @@ interface ISafe {
         bytes calldata data,
         Enum.Operation operation
     ) external returns (bool success);
+
+    function isModuleEnabled(address module) external view returns (bool);
 }
 
 interface ISafeECDSAPlugin {
@@ -47,6 +49,7 @@ contract SafeECDSARecoveryPlugin {
         bytes32 expectedGuardianHash
     );
     error SAFE_ZERO_ADDRESS();
+    error MODULE_NOT_ENABLED();
     error MSG_SENDER_NOT_PLUGIN_OWNER(address sender, address pluginOwner);
     error ATTEMPTING_RESET_ON_WRONG_SAFE(
         address attemptedSafe,
@@ -77,6 +80,9 @@ contract SafeECDSARecoveryPlugin {
         address ecsdaPlugin
     ) external {
         if (safe == address(0)) revert SAFE_ZERO_ADDRESS();
+
+        bool moduleEnabled = ISafe(safe).isModuleEnabled(address(this));
+        if (!moduleEnabled) revert MODULE_NOT_ENABLED();
 
         address owner = ISafeECDSAPlugin(ecsdaPlugin).getOwner(safe);
         if (msg.sender != owner)

--- a/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
@@ -51,6 +51,10 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
             payable(address(0))
         );
 
+        vm.startPrank(safeAddress);
+        safe.enableModule(address(safeECDSARecoveryPlugin));
+        vm.stopPrank();
+
         RECOVERY_HASH_DOMAIN = keccak256(
             abi.encodePacked(
                 "RECOVERY_PLUGIN",
@@ -76,6 +80,33 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         safeECDSARecoveryPlugin.addRecoveryAccount(
             recoveryHash,
             safeZeroAddress,
+            address(safeECDSAPlugin)
+        );
+    }
+
+    function test_addRecoveryAccount_ModuleNotEnabled() public {
+        // Arrange
+        address recoveryAccount = Bob.addr;
+        string memory salt = "test salt";
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
+        );
+
+        address prevModuleInLinkedList = address(0x1);
+        address moduleToDisable = address(safeECDSARecoveryPlugin);
+
+        // Act
+        vm.startPrank(safeAddress);
+        safe.disableModule(prevModuleInLinkedList, moduleToDisable);
+        vm.stopPrank();
+
+        // Assert
+        vm.startPrank(owner);
+        vm.expectRevert(SafeECDSARecoveryPlugin.MODULE_NOT_ENABLED.selector);
+        safeECDSARecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            safeAddress,
             address(safeECDSAPlugin)
         );
     }
@@ -216,10 +247,6 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
             abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
 
-        vm.startPrank(safeAddress);
-        safe.enableModule(address(safeECDSARecoveryPlugin));
-        vm.stopPrank();
-
         vm.startPrank(owner);
         safeECDSARecoveryPlugin.addRecoveryAccount(
             recoveryHash,
@@ -258,10 +285,6 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         bytes32 recoveryHash = keccak256(
             abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
-
-        vm.startPrank(safeAddress);
-        safe.enableModule(address(safeECDSARecoveryPlugin));
-        vm.stopPrank();
 
         vm.startPrank(owner);
         safeECDSARecoveryPlugin.addRecoveryAccount(
@@ -303,10 +326,6 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
             abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
 
-        vm.startPrank(safeAddress);
-        safe.enableModule(address(safeECDSARecoveryPlugin));
-        vm.stopPrank();
-
         vm.startPrank(owner);
         safeECDSARecoveryPlugin.addRecoveryAccount(
             recoveryHash,
@@ -347,10 +366,6 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         bytes32 recoveryHash = keccak256(
             abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
-
-        vm.startPrank(safeAddress);
-        safe.enableModule(address(safeECDSARecoveryPlugin));
-        vm.stopPrank();
 
         vm.startPrank(owner);
         safeECDSARecoveryPlugin.addRecoveryAccount(

--- a/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeECDSARecoveryPlugin.t.sol
@@ -24,6 +24,8 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
 
     address public owner;
 
+    bytes32 RECOVERY_HASH_DOMAIN;
+
     function setUp() public {
         safeECDSARecoveryPlugin = new SafeECDSARecoveryPlugin();
         safeECDSAPlugin = new SafeECDSAPlugin(entryPointAddress);
@@ -48,6 +50,15 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
             0,
             payable(address(0))
         );
+
+        RECOVERY_HASH_DOMAIN = keccak256(
+            abi.encodePacked(
+                "RECOVERY_PLUGIN",
+                uint256(1),
+                block.chainid,
+                address(safeECDSARecoveryPlugin)
+            )
+        );
     }
 
     function test_addRecoveryAccount_SafeZeroAddress() public {
@@ -56,14 +67,7 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
         address safeZeroAddress = address(0);
 
@@ -82,14 +86,7 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
 
         // Act & Assert
@@ -114,14 +111,7 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
 
         // Act
@@ -149,12 +139,10 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash1 = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
+            abi.encodePacked(
+                RECOVERY_HASH_DOMAIN,
                 recoveryAccount1,
-                address(safeECDSARecoveryPlugin),
                 owner,
-                block.chainid,
                 salt
             )
         );
@@ -163,12 +151,10 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         address secondOwner = Dave.addr;
 
         bytes32 guardianHash2 = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
+            abi.encodePacked(
+                RECOVERY_HASH_DOMAIN,
                 recoveryAccount2,
-                address(safeECDSARecoveryPlugin),
-                secondOwner,
-                block.chainid,
+                owner,
                 salt
             )
         );
@@ -218,25 +204,16 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "INVALID_DOMAIN",
+            abi.encodePacked(
+                "INVALID_RECOVERY_HASH_DOMAIN",
                 recoveryAccount,
-                address(safeECDSARecoveryPlugin),
                 owner,
-                block.chainid,
                 salt
             )
         );
 
         bytes32 expectedGuardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
         Vm.Wallet memory newOwner = Carol;
 
@@ -283,14 +260,7 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
         Vm.Wallet memory newOwner = Carol;
         address wrongSafeAddress = Dave.addr;
@@ -334,19 +304,12 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
         Vm.Wallet memory newOwner = Carol;
 
         bytes32 invalidOwnerHash = keccak256(
-            abi.encode("invalid address hash")
+            abi.encodePacked("invalid address hash")
         );
         bytes32 ethSignedHash = invalidOwnerHash.toEthSignedMessageHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(newOwner, ethSignedHash);
@@ -385,18 +348,11 @@ contract SafeECDSARecoveryPluginTest is TestHelper {
         string memory salt = "test salt";
 
         bytes32 guardianHash = keccak256(
-            abi.encode(
-                "RECOVER_ACCOUNT_DOMAIN",
-                recoveryAccount,
-                address(safeECDSARecoveryPlugin),
-                owner,
-                block.chainid,
-                salt
-            )
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, recoveryAccount, owner, salt)
         );
         Vm.Wallet memory newOwner = Carol;
 
-        bytes32 currentOwnerHash = keccak256(abi.encode(owner));
+        bytes32 currentOwnerHash = keccak256(abi.encodePacked(owner));
         bytes32 ethSignedHash = currentOwnerHash.toEthSignedMessageHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(newOwner, ethSignedHash);
         bytes memory newOwnerSignature = abi.encodePacked(r, s, v); // note the order here is different from the tuple above.

--- a/account-integrations/safe/test/forge/utils/TestHelper.sol
+++ b/account-integrations/safe/test/forge/utils/TestHelper.sol
@@ -5,24 +5,29 @@ import "forge-std/Test.sol";
 import {EntryPoint, UserOperation} from "account-abstraction/contracts/core/EntryPoint.sol";
 
 /* solhint-disable private-vars-leading-underscore */
+/* solhint-disable var-name-mixedcase */
 
 abstract contract TestHelper is Test {
     EntryPoint public entryPoint;
     address internal entryPointAddress;
 
-    address internal constant ALICE = address(2); // don't start at 1 as clashes with safe contracts sentinel address
-    address internal constant BOB = address(3);
-    address internal constant CAROL = address(4);
-    address internal constant DAVE = address(5);
-    address[] internal testAccounts = [ALICE, BOB, CAROL, DAVE];
+    Vm.Wallet internal Alice;
+    Vm.Wallet internal Bob;
+    Vm.Wallet internal Carol;
+    Vm.Wallet internal Dave;
 
     constructor() {
         entryPoint = new EntryPoint();
         entryPointAddress = address(entryPoint);
+
+        Alice = vm.createWallet("Alice");
+        Bob = vm.createWallet("Bob");
+        Carol = vm.createWallet("Carol");
+        Dave = vm.createWallet("Dave");
     }
 
-    function buildUserOp() public pure returns (UserOperation memory userOp) {
-        address sender = ALICE;
+    function buildUserOp() public view returns (UserOperation memory userOp) {
+        address sender = Alice.addr;
         uint256 nonce = 0;
         bytes memory initCode = hex"00";
         bytes memory callData = hex"00";

--- a/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
@@ -110,7 +110,7 @@ describe("SafeECDSARecoveryPlugin", () => {
       ["RECOVERY_PLUGIN", 1, chainId, recoveryPluginAddress],
     );
 
-    const guardianHash = ethers.solidityPackedKeccak256(
+    const recoveryHash = ethers.solidityPackedKeccak256(
       ["bytes32", "address", "address", "string"],
       [recoveryhashDomain, recoverySigner.address, safeSigner.address, salt],
     );
@@ -118,7 +118,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     await recoveryPlugin
       .connect(safeSigner)
       .addRecoveryAccount(
-        guardianHash,
+        recoveryHash,
         safeCounterfactualAddress,
         ecdsaPluginAddress,
       );


### PR DESCRIPTION
This PR:
- Improves guardian privacy by storing a hash instead of a guardian address
- Creates a `RECOVERY_HASH_DOMAIN` to improve recovery security
- Stores recovery hashes by safe address instead of owner address. This is because it is possible that a single owner can manage more than one safe. So there would be a collision when that owner enabled a guardian with their second safe.
- Passes a signature signed by the new owner to `resetEcdsaAddress` to prove recovery is accepted by the new owner
- Adds a check to ensure the module is enabled before it can be used
