### PR TITLE
Use top-level compression

### DIFF
--- a/account-integrations/compression/README.md
+++ b/account-integrations/compression/README.md
@@ -44,7 +44,7 @@ paragraph more thoroughly and document it.)
 
 ## Requirements
 
-- The bundler needs to use [`EntryPointCaller`](./src/EntryPointCaller.sol)
+- The bundler needs to use [`HandleAggregatedOpsCaller`](./src/HandleAggregatedOpsCaller.sol)
   (or something better) (including the off-chain compression needed to call it
   correctly)
 - The account (aka SCW) needs to decompress its `userOp.calldata` field similar

--- a/account-integrations/compression/src/HandleAggregatedOpsCaller.sol
+++ b/account-integrations/compression/src/HandleAggregatedOpsCaller.sol
@@ -14,7 +14,7 @@ import {AddressRegistry} from "./AddressRegistry.sol";
 import {RegIndex} from "./RegIndex.sol";
 import {PseudoFloat} from "./PseudoFloat.sol";
 
-contract EntryPointCaller {
+contract HandleAggregatedOpsCaller {
     IEntryPoint entryPoint;
     address payable beneficiary;
     IAggregator aggregator;

--- a/account-integrations/compression/src/HandleOpsCaller.sol
+++ b/account-integrations/compression/src/HandleOpsCaller.sol
@@ -1,0 +1,111 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.7.0 <0.9.0;
+pragma abicoder v2;
+
+import {
+    IEntryPoint,
+    UserOperation
+} from "./I4337.sol";
+import {VLQ} from "./VLQ.sol";
+import {BitStack} from "./BitStack.sol";
+import {AddressRegistry} from "./AddressRegistry.sol";
+import {RegIndex} from "./RegIndex.sol";
+import {PseudoFloat} from "./PseudoFloat.sol";
+
+contract HandleOpsCaller {
+    IEntryPoint entryPoint;
+    address payable beneficiary;
+
+    AddressRegistry registry;
+
+    constructor(
+        IEntryPoint entryPointParam,
+        address payable beneficiaryParam,
+        AddressRegistry registryParam
+    ) {
+        entryPoint = entryPointParam;
+        beneficiary = beneficiaryParam;
+        registry = registryParam;
+    }
+
+    fallback(bytes calldata stream) external returns (bytes memory) {
+        uint256 len;
+        (len, stream) = VLQ.decode(stream);
+
+        uint256 bitStack;
+        (bitStack, stream) = VLQ.decode(stream);
+
+        UserOperation[] memory ops = new UserOperation[](len);
+
+        for (uint256 i = 0; i < len; i++) {
+            UserOperation memory op = ops[i];
+
+            (
+                op.sender,
+                stream,
+                bitStack
+            ) = decodeAddress(stream, bitStack);
+
+            (op.nonce, stream) = VLQ.decode(stream);
+
+            bool hasInitCode;
+            (hasInitCode, bitStack) = BitStack.pop(bitStack);
+
+            if (hasInitCode) {
+                (op.initCode, stream) = decodeBytes(stream);
+            }
+
+            (op.callData, stream) = decodeBytes(stream);
+            (op.callGasLimit, stream) = PseudoFloat.decode(stream);
+            (op.verificationGasLimit, stream) = PseudoFloat.decode(stream);
+            (op.preVerificationGas, stream) = PseudoFloat.decode(stream);
+            (op.maxFeePerGas, stream) = PseudoFloat.decode(stream);
+            (op.maxPriorityFeePerGas, stream) = PseudoFloat.decode(stream);
+
+            bool hasPaymaster;
+            (hasPaymaster, bitStack) = BitStack.pop(bitStack);
+
+            if (hasPaymaster) {
+                (op.paymasterAndData, stream) = decodeBytes(stream);
+            }
+
+            (op.signature, stream) = decodeBytes(stream);
+        }
+
+        entryPoint.handleOps(ops, beneficiary);
+
+        return hex"";
+    }
+
+    function decodeAddress(
+        bytes calldata stream,
+        uint256 bitStack
+    ) internal view returns (
+        address,
+        bytes calldata,
+        uint256
+    ) {
+        bool useRegistry;
+        (useRegistry, bitStack) = BitStack.pop(bitStack);
+
+        if (useRegistry) {
+            uint256 id;
+            (id, stream) = RegIndex.decode(stream);
+
+            return (registry.lookup(id), stream, bitStack);
+        }
+
+        return (address(bytes20(stream[:20])), stream[20:], bitStack);
+    }
+
+    function decodeBytes(
+        bytes calldata stream
+    ) internal pure returns (bytes memory, bytes calldata) {
+        uint256 len;
+        (len, stream) = VLQ.decode(stream);
+        bytes memory bytes_ = stream[:len];
+        stream = stream[len:];
+
+        return (bytes_, stream);
+    }
+}

--- a/account-integrations/compression/src/I4337.sol
+++ b/account-integrations/compression/src/I4337.sol
@@ -3,6 +3,11 @@ pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 interface IEntryPoint {
+    function handleOps(
+        UserOperation[] calldata ops,
+        address payable beneficiary
+    ) external;
+
     function handleAggregatedOps(
         UserOpsPerAggregator[] calldata opsPerAggregator,
         address payable beneficiary

--- a/account-integrations/compression/test/HandleAggregatedOpsCaller.t.sol
+++ b/account-integrations/compression/test/HandleAggregatedOpsCaller.t.sol
@@ -98,7 +98,7 @@ contract HandleAggregatedOpsCallerTest is Test {
         });
 
         assertEq(
-            entryPoint.params(),
+            entryPoint.handleAggregatedOpsParams(),
             abi.encode(bundle, payable(address(this)))
         );
     }

--- a/account-integrations/compression/test/HandleAggregatedOpsCaller.t.sol
+++ b/account-integrations/compression/test/HandleAggregatedOpsCaller.t.sol
@@ -3,18 +3,18 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 
-import {EntryPointCaller} from "../src/EntryPointCaller.sol";
+import {HandleAggregatedOpsCaller} from "../src/HandleAggregatedOpsCaller.sol";
 import {AddressRegistry} from "../src/AddressRegistry.sol";
 import {UserOperation, UserOpsPerAggregator} from "../src/I4337.sol";
 
 import {MockEntryPoint} from "./helpers/MockEntryPoint.sol";
 import {MockAggregator} from "./helpers/MockAggregator.sol";
 
-contract EntryPointCallerTest is Test {
+contract HandleAggregatedOpsCallerTest is Test {
     MockEntryPoint entryPoint;
     MockAggregator aggregator;
     AddressRegistry registry;
-    EntryPointCaller entryPointCaller;
+    HandleAggregatedOpsCaller handleAggregatedOpsCaller;
 
     bytes signature = (
         hex"000102030405060708090a0b0c0d0e0f"
@@ -28,7 +28,7 @@ contract EntryPointCallerTest is Test {
         aggregator = new MockAggregator();
         registry = new AddressRegistry();
 
-        entryPointCaller = new EntryPointCaller(
+        handleAggregatedOpsCaller = new HandleAggregatedOpsCaller(
             entryPoint,
             payable(address(this)),
             aggregator,
@@ -46,7 +46,7 @@ contract EntryPointCallerTest is Test {
     }
 
     function test_one() public {
-        (bool success,) = address(entryPointCaller).call(bytes.concat(
+        (bool success,) = address(handleAggregatedOpsCaller).call(bytes.concat(
             hex"01" // one operation
             hex"09" // bit stack: (1)001
                     // - 1: use registry for sender

--- a/account-integrations/compression/test/HandleOpsCaller.t.sol
+++ b/account-integrations/compression/test/HandleOpsCaller.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import {HandleOpsCaller} from "../src/HandleOpsCaller.sol";
+import {AddressRegistry} from "../src/AddressRegistry.sol";
+import {UserOperation, UserOpsPerAggregator} from "../src/I4337.sol";
+
+import {MockEntryPoint} from "./helpers/MockEntryPoint.sol";
+import {MockAggregator} from "./helpers/MockAggregator.sol";
+
+contract HandleOpsCallerTest is Test {
+    MockEntryPoint entryPoint;
+    AddressRegistry registry;
+    HandleOpsCaller handleOpsCaller;
+
+    bytes signature = (
+        hex"0102030405"
+    );
+
+    function setUp() public {
+        entryPoint = new MockEntryPoint();
+        registry = new AddressRegistry();
+
+        handleOpsCaller = new HandleOpsCaller(
+            entryPoint,
+            payable(address(this)),
+            registry
+        );
+
+        registry.register(address(0xdead));
+        registry.register(address(0xdead));
+        registry.register(address(0xdead));
+        registry.register(address(0xdead));
+
+        registry.register(address(0xa));
+        registry.register(address(0xb));
+        registry.register(address(0xc));
+    }
+
+    function test_one() public {
+        (bool success,) = address(handleOpsCaller).call(bytes.concat(
+            hex"01" // one operation
+            hex"09" // bit stack: (1)001
+                    // - 1: use registry for sender
+                    // - 0: no initCode
+                    // - 0: no paymaster
+                    // - 1: end of stack
+
+            hex"000004" // sender = 0xa via registry
+            hex"03" // nonce = 3
+
+            hex"0b" // 11 bytes of calldata
+            hex"000102030405060708090a" // calldata
+
+            hex"1f53" // callGasLimit = 67,100
+            hex"2500" // verificationGasLimit = 5,000
+            hex"2b0f" // preVerificationGas = 1,230,000
+
+            hex"3900" // maxFeePerGas = 0.001 gwei
+            hex"3100" // maxPriorityFeePerGas = 0.0001 gwei
+
+            hex"05"   // 5 bytes for signature
+            ,
+
+            signature
+        ));
+
+        assertEq(success, true);
+
+        UserOperation[] memory ops = new UserOperation[](1);
+
+        ops[0] = UserOperation({
+            sender: address(0xa),
+            nonce: 3,
+            initCode: hex"",
+            callData: hex"000102030405060708090a",
+            callGasLimit: 67_100,
+            verificationGasLimit: 5_000,
+            preVerificationGas: 1_230_000,
+            maxFeePerGas: 1_000_000,
+            maxPriorityFeePerGas: 100_000,
+            paymasterAndData: hex"",
+            signature: signature
+        });
+
+        assertEq(
+            entryPoint.handleOpsParams(),
+            abi.encode(ops, payable(address(this)))
+        );
+    }
+}

--- a/account-integrations/compression/test/helpers/MockEntryPoint.sol
+++ b/account-integrations/compression/test/helpers/MockEntryPoint.sol
@@ -4,15 +4,23 @@ pragma abicoder v2;
 
 import "forge-std/Test.sol";
 
-import {IEntryPoint, UserOpsPerAggregator} from "../../src/I4337.sol";
+import {IEntryPoint, UserOperation, UserOpsPerAggregator} from "../../src/I4337.sol";
 
 contract MockEntryPoint is IEntryPoint {
-    bytes public params;
+    bytes public handleOpsParams;
+    bytes public handleAggregatedOpsParams;
+
+    function handleOps(
+        UserOperation[] calldata ops,
+        address payable beneficiary
+    ) external {
+        handleOpsParams = abi.encode(ops, beneficiary);
+    }
 
     function handleAggregatedOps(
         UserOpsPerAggregator[] calldata opsPerAggregator,
         address payable beneficiary
     ) external {
-        params = abi.encode(opsPerAggregator, beneficiary);
+        handleAggregatedOpsParams = abi.encode(opsPerAggregator, beneficiary);
     }
 }

--- a/demos/inpage/hardhat/contracts/imports.sol
+++ b/demos/inpage/hardhat/contracts/imports.sol
@@ -11,4 +11,5 @@ import {SafeCompressionFactory} from "../lib/account-integrations/safe/src/SafeC
 import {SafeCompressionPlugin} from "../lib/account-integrations/safe/src/SafeCompressionPlugin.sol";
 import {FallbackDecompressor} from "../lib/account-integrations/compression/src/decompressors/FallbackDecompressor.sol";
 import {AddressRegistry} from "../lib/account-integrations/compression/src/AddressRegistry.sol";
+import {HandleOpsCaller} from "../lib/account-integrations/compression/src/HandleOpsCaller.sol";
 import {SafeECDSARecoveryPlugin} from "../lib/account-integrations/safe/src/SafeECDSARecoveryPlugin.sol";

--- a/demos/inpage/src/WaxInPage.tsx
+++ b/demos/inpage/src/WaxInPage.tsx
@@ -51,11 +51,13 @@ type Config = {
   requirePermission: boolean;
   deployContractsIfNeeded: boolean;
   ethersPollingInterval?: number;
+  useTopLevelCompression?: boolean;
 };
 
 const defaultConfig: Config = {
   requirePermission: true,
   deployContractsIfNeeded: true,
+  useTopLevelCompression: true,
 };
 
 let ethersDefaultPollingInterval = 4000;

--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -113,3 +113,7 @@ export function encodeBitStack(bits: boolean[]) {
 
   return stackVLQ;
 }
+
+export function encodeBytes(bytes: string) {
+  return hexJoin([encodeVLQ(BigInt(hexLen(bytes))), bytes]);
+}


### PR DESCRIPTION
## What is this PR doing?

Adds top-level compression to the inpage demo. This means the internal bundler calls `HandleOpsCaller` instead of the `EntryPoint`, so that the top-level calldata can be compressed off-chain, and `HandleOpsCaller` decompresses it before passing it on to `EntryPoint`.

## How can these changes be manually tested?

Send a transaction using the inpage demo. In the console you should see a log like `logBytes: EntryPoint tx is 319 bytes: ...`.

Top-level compression can be turned off using `waxInPage.setConfig({ useTopLevelCompression: false })` (in the console).

If you send another transaction, you should see a log like `logBytes: EntryPoint tx is 951 bytes: ...`.

Depending on the account type used and the type of transactions, the numbers will be different, but it should be dramatically fewer bytes when compression is enabled.

## Does this PR resolve or contribute to any issues?

Resolves #112.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
