### PR TITLE
Round up to 3 significant figures to make pseudofloats smaller

### DIFF
--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -117,3 +117,25 @@ export function encodeBitStack(bits: boolean[]) {
 export function encodeBytes(bytes: string) {
   return hexJoin([encodeVLQ(BigInt(hexLen(bytes))), bytes]);
 }
+
+export function roundUpPseudoFloat(x: bigint) {
+  let pow10 = 1n;
+
+  while (pow10 < x) {
+    pow10 *= 10n;
+  }
+
+  pow10 /= 1000n;
+
+  if (pow10 === 0n) {
+    return x;
+  }
+
+  const roundedDown = pow10 * (x / pow10);
+
+  if (roundedDown === x) {
+    return x;
+  }
+
+  return roundedDown + pow10;
+}


### PR DESCRIPTION
## What is this PR doing?

Rounds gas-related fields up to 3 significant figures so they can be encoded in 2 bytes by pseudofloat. This results in about a 1% error in the worst case (eg 100,001 -> 101,000).

```solidity
struct UserOperation {
    address sender;
    uint256 nonce;
    bytes initCode;
    bytes callData;
    uint256 callGasLimit;         // <-------------
    uint256 verificationGasLimit; // <-------------
    uint256 preVerificationGas;   // <------------- These fields
    uint256 maxFeePerGas;         // <-------------
    uint256 maxPriorityFeePerGas; // <-------------
    bytes paymasterAndData;
    bytes signature;
}
```

## How can these changes be manually tested?

The size of `EntryPoint tx` and `EntryPoint calldata` is about 4 bytes smaller after this change. (Search `logBytes` in the dev console.)

## Does this PR resolve or contribute to any issues?

Resolves #159.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
