### PR TITLE
Compression: Fix ABI overhead for decompressAndPerform in top-level compression

### DIFF
--- a/account-integrations/compression/src/HandleAggregatedOpsCaller.sol
+++ b/account-integrations/compression/src/HandleAggregatedOpsCaller.sol
@@ -61,6 +61,14 @@ contract HandleAggregatedOpsCaller {
             }
 
             (op.callData, stream) = decodeBytes(stream);
+
+            bool usesDecompressAndPerform;
+            (usesDecompressAndPerform, bitStack) = BitStack.pop(bitStack);
+
+            if (usesDecompressAndPerform) {
+                op.callData = abi.encodeWithSignature("decompressAndPerform(bytes)", op.callData);
+            }
+
             (op.callGasLimit, stream) = PseudoFloat.decode(stream);
             (op.verificationGasLimit, stream) = PseudoFloat.decode(stream);
             (op.preVerificationGas, stream) = PseudoFloat.decode(stream);

--- a/account-integrations/compression/src/HandleOpsCaller.sol
+++ b/account-integrations/compression/src/HandleOpsCaller.sol
@@ -56,6 +56,14 @@ contract HandleOpsCaller {
             }
 
             (op.callData, stream) = decodeBytes(stream);
+
+            bool usesDecompressAndPerform;
+            (usesDecompressAndPerform, bitStack) = BitStack.pop(bitStack);
+
+            if (usesDecompressAndPerform) {
+                op.callData = abi.encodeWithSignature("decompressAndPerform(bytes)", op.callData);
+            }
+
             (op.callGasLimit, stream) = PseudoFloat.decode(stream);
             (op.verificationGasLimit, stream) = PseudoFloat.decode(stream);
             (op.preVerificationGas, stream) = PseudoFloat.decode(stream);

--- a/account-integrations/compression/test/HandleOpsCaller.t.sol
+++ b/account-integrations/compression/test/HandleOpsCaller.t.sol
@@ -42,9 +42,10 @@ contract HandleOpsCallerTest is Test {
     function test_one() public {
         (bool success,) = address(handleOpsCaller).call(bytes.concat(
             hex"01" // one operation
-            hex"09" // bit stack: (1)001
+            hex"11" // bit stack: (1)0001
                     // - 1: use registry for sender
                     // - 0: no initCode
+                    // - 0: don't encode decompressAndPerform
                     // - 0: no paymaster
                     // - 1: end of stack
 
@@ -76,6 +77,74 @@ contract HandleOpsCallerTest is Test {
             nonce: 3,
             initCode: hex"",
             callData: hex"000102030405060708090a",
+            callGasLimit: 67_100,
+            verificationGasLimit: 5_000,
+            preVerificationGas: 1_230_000,
+            maxFeePerGas: 1_000_000,
+            maxPriorityFeePerGas: 100_000,
+            paymasterAndData: hex"",
+            signature: signature
+        });
+
+        assertEq(
+            entryPoint.handleOpsParams(),
+            abi.encode(ops, payable(address(this)))
+        );
+    }
+
+    function test_decompressAndPerform() public {
+        (bool success,) = address(handleOpsCaller).call(bytes.concat(
+            hex"01" // one operation
+            hex"15" // bit stack: (1)0101
+                    // - 1: use registry for sender
+                    // - 0: no initCode
+                    // - 1: encode decompressAndPerform
+                    // - 0: no paymaster
+                    // - 1: end of stack
+
+            hex"000004" // sender = 0xa via registry
+            hex"03" // nonce = 3
+
+            hex"0b" // 11 bytes of calldata
+            hex"000102030405060708090a" // bytes of decompressAndPerform
+
+            hex"1f53" // callGasLimit = 67,100
+            hex"2500" // verificationGasLimit = 5,000
+            hex"2b0f" // preVerificationGas = 1,230,000
+
+            hex"3900" // maxFeePerGas = 0.001 gwei
+            hex"3100" // maxPriorityFeePerGas = 0.0001 gwei
+
+            hex"05"   // 5 bytes for signature
+            ,
+
+            signature
+        ));
+
+        assertEq(success, true);
+
+        UserOperation[] memory ops = new UserOperation[](1);
+
+        ops[0] = UserOperation({
+            sender: address(0xa),
+            nonce: 3,
+            initCode: hex"",
+            callData: (
+                // Method signature of decompressAndPerform(bytes)
+                hex"2d1634c5"
+
+                // Location of bytes argument
+                hex"0000000000000000000000000000000000000000000000000000000000000020"
+
+                // Length of bytes argument
+                hex"000000000000000000000000000000000000000000000000000000000000000b"
+
+                // Actual data to be decompressed inside account
+                hex"000102030405060708090a"
+
+                // Padding
+                hex"000000000000000000000000000000000000000000"
+            ),
             callGasLimit: 67_100,
             verificationGasLimit: 5_000,
             preVerificationGas: 1_230_000,

--- a/demos/inpage/src/bundlers/SimulatedBundler.ts
+++ b/demos/inpage/src/bundlers/SimulatedBundler.ts
@@ -61,8 +61,8 @@ export default class SimulatedBundler implements IBundler {
     }
 
     const tx = ethers.Transaction.from(txResponse);
-    this.#waxInPage.logBytes('Entrypoint calldata', tx.data);
-    this.#waxInPage.logBytes('EntryPoint tx', tx.serialized);
+    this.#waxInPage.logBytes('Top-level calldata', tx.data);
+    this.#waxInPage.logBytes('Top-level tx', tx.serialized);
 
     void txResponse.wait().then((receipt) => {
       if (!receipt) {
@@ -71,7 +71,7 @@ export default class SimulatedBundler implements IBundler {
       }
 
       if (receipt) {
-        console.log('EntryPoint gas used:', receipt.gasUsed.toString());
+        console.log('Top-level gas used:', receipt.gasUsed.toString());
       }
     });
 

--- a/demos/inpage/src/bundlers/SimulatedBundler.ts
+++ b/demos/inpage/src/bundlers/SimulatedBundler.ts
@@ -247,7 +247,8 @@ export default class SimulatedBundler implements IBundler {
         parts.push(encodeBytes(op.initCode));
       }
 
-      parts.push(encodeBytes(op.callData));
+      SimulatedBundler.encodeUserOpCalldata(bits, parts, op.callData);
+
       parts.push(encodePseudoFloat(BigInt(op.callGasLimit)));
       parts.push(encodePseudoFloat(BigInt(op.verificationGasLimit)));
       parts.push(encodePseudoFloat(BigInt(op.preVerificationGas)));
@@ -269,6 +270,44 @@ export default class SimulatedBundler implements IBundler {
     return hexJoin([encodedLen, encodeBitStack(bits), ...encodedOps]);
   }
 
+  static encodeUserOpCalldata(
+    bits: boolean[],
+    parts: string[],
+    calldata: string,
+  ) {
+    let decompressAndPerformBytes: string | undefined;
+
+    if (calldata.startsWith(decompressAndPerformSelector)) {
+      const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+      try {
+        const bytesArg = abiCoder.decode(
+          ['bytes'],
+          `0x${calldata.slice(10)}`,
+        )[0] as string;
+
+        if (
+          hexJoin([
+            decompressAndPerformSelector,
+            abiCoder.encode(['bytes'], [bytesArg]),
+          ]) === calldata
+        ) {
+          decompressAndPerformBytes = bytesArg;
+        }
+      } catch {
+        // Fallthrough to default that handles any calldata
+      }
+    }
+
+    if (decompressAndPerformBytes !== undefined) {
+      bits.push(true);
+      parts.push(encodeBytes(decompressAndPerformBytes));
+    } else {
+      bits.push(false);
+      parts.push(encodeBytes(calldata));
+    }
+  }
+
   static roundUpGasEstimate({
     preVerificationGas,
     verificationGasLimit,
@@ -284,3 +323,8 @@ export default class SimulatedBundler implements IBundler {
     };
   }
 }
+
+const decompressAndPerformSelector = ethers.FunctionFragment.getSelector(
+  'decompressAndPerform',
+  ['bytes'],
+);


### PR DESCRIPTION
# *Dependent PR*

This PR builds on https://github.com/getwax/wax/pull/163, please merge that PR first.

## What is this PR doing?

When calling a compression-enabled wallet, you use `decompressAndPerform(bytes)`. This causes a lot of overhead in the solidity abi as documented in the code:

```solidity
// wax/account-integrations/compression/test/HandleOpsCaller.t.sol:132:
            callData: (
                // Method signature of decompressAndPerform(bytes)
                hex"2d1634c5"

                // Location of bytes argument
                hex"0000000000000000000000000000000000000000000000000000000000000020"

                // Length of bytes argument
                hex"000000000000000000000000000000000000000000000000000000000000000b"

                // Actual data to be decompressed inside account
                hex"000102030405060708090a"

                // Padding
                hex"000000000000000000000000000000000000000000"
            ),
```

This PR introduces a new bit flag to indicate whether `decompressAndPerform(bytes)` is being used. In this case, the encoded call to `HandleOpsCaller`/`HandleAggregatedOpsCaller` can include just the actual bytes for this method instead of the entire calldata. It'll then be expanded to solidity's abi format before being passed to the account.

## How can these changes be manually tested?

In the inpage wallet, send an eth transfer using a compression account. In the dev console, you should see a message like this:
```
logBytes: Top-level calldata is 125 bytes: 0x0114012cf4ed673f890f1b160a2305d2af60fc37aa9603190102012cf4ed673f890f1b160a2305d2af60fc37aa968100001f4931002406420f5100410330569e39ac636e1ee2ab68b2ba77c1b94ebceabe296770e39536c623151eae66d6ae6b00ba7cd7f84f072f080f35f198efea0d44a998db9ed450296fb357b51b
```

Using a recovery account, this top-level calldata is much larger:
```
logBytes: Top-level calldata is 233 bytes: 0x0110f6697eea89189e0857579ddbe727fac9ece8d08f008104ab4ed83e000000000000000000000000f6697eea89189e0857579ddbe727fac9ece8d08f00000000000000000000000000000000000000000000000000038d7ea4c6800000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000193b31001e41400e510041bcd4384a5ff0d48b34866b94bc7cf6640e1fd60938df4a6bb1aede609a13525f42edc27d56277cc32d8bf87095803b7655e63d300bd72b38b4048ba47cb2f7fd1b
```

## Does this PR resolve or contribute to any issues?

Resolves #164.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
