### PR TITLE
Use AddressRegistry in inpage demo

### DIFF
--- a/demos/inpage/demo/LinksPage.tsx
+++ b/demos/inpage/demo/LinksPage.tsx
@@ -17,13 +17,14 @@ const addFundsDefault = (() => {
 
 const LinksPage = () => {
   const demo = DemoContext.use();
+  const balance = demo.useBalance();
   const [, setPath] = usePath();
   const account = demo.useAccount();
 
   return (
     <div className="links-page">
       <Button
-        secondary
+        secondary={balance === undefined || balance > 0n}
         disabled={account === undefined}
         onPress={async () => {
           if (account === undefined) {

--- a/demos/inpage/demo/LinksPage.tsx
+++ b/demos/inpage/demo/LinksPage.tsx
@@ -78,6 +78,14 @@ const LinksPage = () => {
       )}
       <Button
         secondary
+        onPress={() => {
+          setPath('/registerAddress');
+        }}
+      >
+        Register Address
+      </Button>
+      <Button
+        secondary
         onPress={async () => {
           const granted = await demo.waxInPage.requestPermission(
             'This will reset the in-page wallet, including the stored private key. Are you sure?',

--- a/demos/inpage/demo/PageRouter.tsx
+++ b/demos/inpage/demo/PageRouter.tsx
@@ -3,6 +3,7 @@ import LinksPage from './LinksPage';
 import SendEthPage from './SendEthPage';
 import Recovery from './Recovery';
 import usePath from './usePath';
+import RegisterAddressPage from './RegisterAddressPage';
 
 const PageRouter = () => {
   const [path] = usePath();
@@ -21,6 +22,10 @@ const PageRouter = () => {
 
   if (path === '/recovery') {
     return <Recovery />;
+  }
+
+  if (path === '/registerAddress') {
+    return <RegisterAddressPage />;
   }
 
   return <>Not found</>;

--- a/demos/inpage/demo/RegisterAddressPage.scss
+++ b/demos/inpage/demo/RegisterAddressPage.scss
@@ -1,0 +1,5 @@
+.register-address-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}

--- a/demos/inpage/demo/RegisterAddressPage.tsx
+++ b/demos/inpage/demo/RegisterAddressPage.tsx
@@ -1,12 +1,11 @@
 import './RegisterAddressPage.scss';
 import { useState } from 'react';
-import { ethers } from 'ethers';
 import Button from '../src/Button';
 import Heading from '../src/Heading';
 import DemoContext from './DemoContext';
 import Loading from './Loading';
 import runAsync from './helpers/runAsync';
-import { encodeRegIndex } from '../src/helpers/encodeUtils';
+import { encodeRegIndex, lookupAddress } from '../src/helpers/encodeUtils';
 
 const RegisterAddressPage = () => {
   const demo = DemoContext.use();
@@ -34,21 +33,11 @@ const RegisterAddressPage = () => {
   }
 
   const lookup = async () => {
-    if (!ethers.isAddress(addressInput)) {
-      throw new Error('Address is not valid');
-    }
-
-    const { addressRegistry } = contracts;
-    const filter = addressRegistry.filters[
-      'AddressRegistered(uint256,address)'
-    ](undefined, addressInput);
-
-    const event = (await addressRegistry.queryFilter(filter))[0];
-    const id = event ? event.args[0] : 'none';
+    const id = await lookupAddress(contracts.addressRegistry, addressInput);
 
     setLookupResult({
       address: addressInput,
-      id,
+      id: id ?? 'none',
     });
   };
 

--- a/demos/inpage/demo/RegisterAddressPage.tsx
+++ b/demos/inpage/demo/RegisterAddressPage.tsx
@@ -1,0 +1,95 @@
+import './RegisterAddressPage.scss';
+import { useState } from 'react';
+import { ethers } from 'ethers';
+import Button from '../src/Button';
+import Heading from '../src/Heading';
+import DemoContext from './DemoContext';
+import Loading from './Loading';
+import runAsync from './helpers/runAsync';
+import { encodeRegIndex } from '../src/helpers/encodeUtils';
+
+const RegisterAddressPage = () => {
+  const demo = DemoContext.use();
+  const contracts = demo.useContracts();
+  const signer = demo.useSigner();
+
+  const [addressInput, setAddressInput] = useState('');
+
+  const [lookupResult, setLookupResult] = useState<{
+    address: string;
+    id: bigint | 'none';
+  }>();
+
+  const registeredId =
+    lookupResult?.address === addressInput ? lookupResult.id : 'unknown';
+
+  if (!contracts) {
+    return (
+      <Loading>
+        <Heading>Register Address</Heading>
+        <div>Waiting for contracts</div>
+        <Button onPress={() => demo.getContracts()}>Deploy</Button>
+      </Loading>
+    );
+  }
+
+  const lookup = async () => {
+    if (!ethers.isAddress(addressInput)) {
+      throw new Error('Address is not valid');
+    }
+
+    const { addressRegistry } = contracts;
+    const filter = addressRegistry.filters[
+      'AddressRegistered(uint256,address)'
+    ](undefined, addressInput);
+
+    const event = (await addressRegistry.queryFilter(filter))[0];
+    const id = event ? event.args[0] : 'none';
+
+    setLookupResult({
+      address: addressInput,
+      id,
+    });
+  };
+
+  return (
+    <div className="register-address-page">
+      <Heading>Register Address</Heading>
+      <div>
+        Address:{' '}
+        <input
+          type="text"
+          onInput={(e) => setAddressInput(e.currentTarget.value)}
+        />
+      </div>
+      {registeredId === 'unknown' && (
+        <Button disabled={!signer} onPress={lookup}>
+          Lookup
+        </Button>
+      )}
+      {registeredId === 'none' && (
+        <>
+          <div>Not registered</div>
+          <Button
+            disabled={!signer}
+            onPress={async () => {
+              await contracts.addressRegistry
+                .connect(signer)
+                .register(addressInput);
+
+              await lookup();
+              runAsync(() => demo.refreshBalance());
+            }}
+          >
+            Register
+          </Button>
+        </>
+      )}
+      {typeof registeredId === 'bigint' && (
+        <div>Registered as {encodeRegIndex(registeredId)}</div>
+      )}
+    </div>
+  );
+};
+
+export default RegisterAddressPage;

--- a/demos/inpage/package.json
+++ b/demos/inpage/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react-refresh": "^0.4.1",
     "events": "^3.3.0",
     "prettier": "^3.0.0",
+    "sass": "^1.69.5",
     "ts-node": "^10.9.1",
     "typed-emitter": "^2.1.0",
     "typescript": "^5.0.2",

--- a/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
+++ b/demos/inpage/src/accounts/SafeCompressionAccountWrapper.ts
@@ -16,6 +16,7 @@ import {
   encodeVLQ,
   hexJoin,
   hexLen,
+  lookupAddress,
 } from '../helpers/encodeUtils';
 
 export const SafeCompressionAccountData = z.object({
@@ -112,13 +113,16 @@ export default class SafeCompressionAccountWrapper implements IAccount {
 
   // eslint-disable-next-line @typescript-eslint/require-await, class-methods-use-this
   async encodeActions(actions: EthereumRpc.Action[]): Promise<string> {
+    const contracts = await this.waxInPage.getContracts();
+
     let stream = '0x';
     const bits: boolean[] = [];
 
     for (const action of actions) {
-      const addressIndex: bigint | undefined = undefined;
-
-      // TODO: Find addressIndex using event logs (see issue #122)
+      const addressIndex = await lookupAddress(
+        contracts.addressRegistry,
+        action.to,
+      );
 
       bits.push(addressIndex !== undefined);
 

--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -1,3 +1,6 @@
+import { ethers } from 'ethers';
+import { AddressRegistry } from '../../hardhat/typechain-types';
+
 export function hexJoin(hexStrings: string[]) {
   return `0x${hexStrings.map(remove0x).join('')}`;
 }
@@ -138,4 +141,22 @@ export function roundUpPseudoFloat(x: bigint) {
   }
 
   return roundedDown + pow10;
+}
+
+export async function lookupAddress(
+  registry: AddressRegistry,
+  address: string,
+) {
+  if (!ethers.isAddress(address)) {
+    throw new Error('Address is not valid');
+  }
+
+  const filter = registry.filters['AddressRegistered(uint256,address)'](
+    undefined,
+    address,
+  );
+
+  const event = (await registry.queryFilter(filter)).at(0);
+
+  return event?.args[0];
 }

--- a/demos/inpage/src/helpers/encodeUtils.ts
+++ b/demos/inpage/src/helpers/encodeUtils.ts
@@ -70,7 +70,7 @@ export function encodePseudoFloat(xParam: bigint) {
 
 export function encodeRegIndex(regIndex: bigint) {
   const vlqValue = regIndex / 0x010000n;
-  const fixedValue = Number(regIndex / 0x010000n);
+  const fixedValue = Number(regIndex % 0x010000n);
 
   return hexJoin([
     encodeVLQ(vlqValue),

--- a/demos/inpage/yarn.lock
+++ b/demos/inpage/yarn.lock
@@ -611,6 +611,14 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+anymatch@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -727,6 +735,11 @@ big-integer@^1.6.44:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bplist-parser@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
@@ -742,7 +755,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -776,6 +789,21 @@ chalk@^4.0.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -1487,7 +1515,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1612,6 +1640,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immutable@^4.0.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.4.tgz#2e07b33837b4bb7662f288c244d1ced1ef65a78f"
+  integrity sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -1668,6 +1701,13 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -1715,7 +1755,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -2124,6 +2164,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -2297,7 +2342,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -2366,6 +2411,13 @@ react@^18.2.0:
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
@@ -2468,6 +2520,15 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+sass@^1.69.5:
+  version "1.69.5"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.5.tgz#23e18d1c757a35f2e52cc81871060b9ad653dfde"
+  integrity sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -2530,7 +2591,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
# *Dependent PR*

This PR depends on https://github.com/getwax/wax/pull/165. Please merge that PR first.

## What is this PR doing?

- Makes use of the AddressRegistry in the inpage demo
- Makes `Add Funds` primary when the account has no funds
- Fixed bug in `encodeRegIndex`

## How can these changes be manually tested?

Demo:
[![Demo video](https://img.youtube.com/vi/En-i1brvXss/0.jpg)](https://www.youtube.com/watch?v=En-i1brvXss)

Btw I forgot to mention that in a real product/deployment you'd probably proactively register the user's address without them doing it explicitly (and other common addresses). Another one of those things where we're showcasing dev tools instead of making a product. Curious to sync on that idea if anyone thinks differently.

## Does this PR resolve or contribute to any issues?

Resolves #122.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
