### PR TITLE
Add zk email recovery plugin

### DIFF
--- a/account-integrations/safe/src/SafeZKPPasswordFactory.sol
+++ b/account-integrations/safe/src/SafeZKPPasswordFactory.sol
@@ -9,7 +9,7 @@ import {SafeProxy} from "safe-contracts/contracts/proxies/SafeProxy.sol";
 import {EntryPoint} from "account-abstraction/contracts/core/EntryPoint.sol";
 
 import {SafeZKPPasswordPlugin} from "./SafeZKPPasswordPlugin.sol";
-import {IPasswordVerifier} from "./interface/IPasswordVerifier.sol";
+import {IGroth16Verifier} from "./interface/IGroth16Verifier.sol";
 
 contract SafeZKPPasswordFactory {
     function create(
@@ -17,13 +17,13 @@ contract SafeZKPPasswordFactory {
         EntryPoint entryPoint,
         address owner,
         uint256 saltNonce,
-        IPasswordVerifier verifier
+        IGroth16Verifier verifier
     ) external returns (SafeZKPPasswordPlugin) {
         bytes32 salt = keccak256(abi.encodePacked(owner, saltNonce));
 
-        Safe safe = Safe(payable(new SafeProxy{salt: salt}(
-            address(safeSingleton)
-        )));
+        Safe safe = Safe(
+            payable(new SafeProxy{salt: salt}(address(safeSingleton)))
+        );
 
         address[] memory owners = new address[](1);
         owners[0] = owner;

--- a/account-integrations/safe/src/SafeZKPPasswordPlugin.sol
+++ b/account-integrations/safe/src/SafeZKPPasswordPlugin.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
-import {IPasswordVerifier} from "./interface/IPasswordVerifier.sol";
+import {IGroth16Verifier} from "./interface/IGroth16Verifier.sol";
 import {ISafe} from "./interface/ISafe.sol";
 import {Safe4337Base} from "./utils/Safe4337Base.sol";
 import {IEntryPoint, UserOperation} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
@@ -12,12 +12,11 @@ struct ZKPPasswordOwnerStorage {
 }
 
 contract SafeZKPPasswordPlugin is Safe4337Base {
-
     mapping(address => ZKPPasswordOwnerStorage) public zkpPasswordOwnerStorage;
 
     address public immutable myAddress; // Module address
     address private immutable _entryPoint;
-    IPasswordVerifier private immutable _verifier;
+    IGroth16Verifier private immutable _verifier;
 
     address internal constant _SENTINEL_MODULES = address(0x1);
 
@@ -27,7 +26,7 @@ contract SafeZKPPasswordPlugin is Safe4337Base {
         address indexed newOwner
     );
 
-    constructor(address entryPointAddress, IPasswordVerifier verifier) {
+    constructor(address entryPointAddress, IGroth16Verifier verifier) {
         myAddress = address(this);
         _entryPoint = entryPointAddress;
         _verifier = verifier;
@@ -98,10 +97,13 @@ contract SafeZKPPasswordPlugin is Safe4337Base {
     }
 
     // From https://ethereum.stackexchange.com/a/51234
-    function bytesToUint(bytes32 b) internal pure returns (uint256){
+    function bytesToUint(bytes32 b) internal pure returns (uint256) {
         uint256 number;
-        for(uint i=0;i<b.length;i++){
-            number = number + uint(uint8(b[i]))*(2**(8*(b.length-(i+1))));
+        for (uint i = 0; i < b.length; i++) {
+            number =
+                number +
+                uint(uint8(b[i])) *
+                (2 ** (8 * (b.length - (i + 1))));
         }
         return number;
     }

--- a/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {MockGroth16Verifier} from "./utils/MockGroth16Verifier.sol";
+
+contract Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+interface ISafe {
+    /// @dev Allows a Module to execute a Safe transaction without any further confirmations.
+    /// @param to Destination address of module transaction.
+    /// @param value Ether value of module transaction.
+    /// @param data Data payload of module transaction.
+    /// @param operation Operation type of module transaction.
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation
+    ) external returns (bool success);
+
+    function isModuleEnabled(address module) external view returns (bool);
+}
+
+interface ISafeECDSAPlugin {
+    function getOwner(address safe) external view returns (address);
+}
+
+struct ZkEmailRecoveryStorage {
+    bytes32 recoveryHash;
+}
+
+contract SafeZkEmailRecoveryPlugin {
+    bytes32 immutable RECOVERY_HASH_DOMAIN;
+    string public constant DOMAIN_NAME = "RECOVERY_PLUGIN";
+    uint256 public constant DOMAIN_VERSION = 1;
+
+    mapping(address => ZkEmailRecoveryStorage) public zkEmailRecoveryStorage;
+
+    error INVALID_GUARDIAN_HASH(
+        bytes32 recoveryHash,
+        bytes32 expectedGuardianHash
+    );
+    error MODULE_NOT_ENABLED();
+    error INVALID_OWNER(address expectedOwner, address owner);
+    error INVALID_PROOF();
+
+    MockGroth16Verifier public immutable verifier;
+
+    constructor(address _verifier) {
+        verifier = MockGroth16Verifier(_verifier);
+        RECOVERY_HASH_DOMAIN = keccak256(
+            abi.encodePacked(
+                DOMAIN_NAME,
+                DOMAIN_VERSION,
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    function getZkEmailRecoveryStorage(
+        address safe
+    ) external view returns (ZkEmailRecoveryStorage memory) {
+        return zkEmailRecoveryStorage[safe];
+    }
+
+    function addRecoveryAccount(
+        bytes32 recoveryHash,
+        address owner,
+        address ecsdaPlugin
+    ) external {
+        address safe = msg.sender;
+
+        bool moduleEnabled = ISafe(safe).isModuleEnabled(address(this));
+        if (!moduleEnabled) revert MODULE_NOT_ENABLED();
+
+        address expectedOwner = ISafeECDSAPlugin(ecsdaPlugin).getOwner(safe);
+        if (owner != expectedOwner) revert INVALID_OWNER(expectedOwner, owner);
+
+        zkEmailRecoveryStorage[safe] = ZkEmailRecoveryStorage(recoveryHash);
+    }
+
+    function recoverAccount(
+        address safe,
+        address ecdsaPlugin,
+        address newOwner,
+        string memory salt,
+        bytes32 email,
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory publicSignals
+    ) external {
+        ZkEmailRecoveryStorage memory recoveryStorage = zkEmailRecoveryStorage[
+            safe
+        ];
+
+        // Identity of guardian is protected and it is only revealed on recovery
+        bytes32 expectedRecoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        if (expectedRecoveryHash != recoveryStorage.recoveryHash) {
+            revert INVALID_GUARDIAN_HASH(
+                recoveryStorage.recoveryHash,
+                expectedRecoveryHash
+            );
+        }
+
+        // verify proof
+        bool verified = verifier.verifyProof(a, b, c, publicSignals);
+        if (!verified) revert INVALID_PROOF();
+
+        bytes memory data = abi.encodeWithSignature(
+            "enable(bytes)",
+            abi.encodePacked(newOwner)
+        );
+
+        ISafe(safe).execTransactionFromModule(
+            ecdsaPlugin,
+            0,
+            data,
+            Enum.Operation.Call
+        );
+    }
+}

--- a/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
@@ -24,8 +24,6 @@ contract SafeZkEmailRecoveryPlugin {
     IDKIMRegsitry public immutable defaultDkimRegistry;
 
     bytes32 immutable RECOVERY_HASH_DOMAIN;
-    string public constant DOMAIN_NAME = "RECOVERY_PLUGIN";
-    uint256 public constant DOMAIN_VERSION = 1;
 
     // Mapping of safe address to plugin storage
     mapping(address => ZkEmailRecoveryStorage) public zkEmailRecoveryStorage;
@@ -49,9 +47,12 @@ contract SafeZkEmailRecoveryPlugin {
         defaultDkimRegistry = IDKIMRegsitry(_defaultDkimRegistry);
 
         RECOVERY_HASH_DOMAIN = keccak256(
-            abi.encodePacked(
-                DOMAIN_NAME,
-                DOMAIN_VERSION,
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256("SafeZKEmailRecoveryPlugin"),
+                keccak256("1"),
                 block.chainid,
                 address(this)
             )

--- a/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
@@ -41,9 +41,9 @@ contract SafeZkEmailRecoveryPlugin {
 
     mapping(address => ZkEmailRecoveryStorage) public zkEmailRecoveryStorage;
 
-    error INVALID_GUARDIAN_HASH(
+    error INVALID_RECOVERY_HASH(
         bytes32 recoveryHash,
-        bytes32 expectedGuardianHash
+        bytes32 expectedRecoveryHash
     );
     error MODULE_NOT_ENABLED();
     error INVALID_OWNER(address expectedOwner, address owner);
@@ -100,13 +100,13 @@ contract SafeZkEmailRecoveryPlugin {
             safe
         ];
 
-        // Identity of guardian is protected and it is only revealed on recovery
+        // Email is protected and it is only revealed on recovery
         bytes32 expectedRecoveryHash = keccak256(
             abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
         );
 
         if (expectedRecoveryHash != recoveryStorage.recoveryHash) {
-            revert INVALID_GUARDIAN_HASH(
+            revert INVALID_RECOVERY_HASH(
                 recoveryStorage.recoveryHash,
                 expectedRecoveryHash
             );

--- a/account-integrations/safe/src/interface/IDKIMRegsitry.sol
+++ b/account-integrations/safe/src/interface/IDKIMRegsitry.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Interface for ZKP Passwrod Groth16 verifier
+interface IDKIMRegsitry {
+    function isDKIMPublicKeyHashValid(
+        string memory domainName,
+        bytes32 publicKeyHash
+    ) external view returns (bool);
+}

--- a/account-integrations/safe/src/interface/IGroth16Verifier.sol
+++ b/account-integrations/safe/src/interface/IGroth16Verifier.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 /// @title Interface for ZKP Passwrod Groth16 verifier
-interface IPasswordVerifier {
+interface IGroth16Verifier {
     function verifyProof(
         uint256[2] memory a,
         uint256[2][2] memory b,

--- a/account-integrations/safe/src/utils/MockDKIMRegsitry.sol
+++ b/account-integrations/safe/src/utils/MockDKIMRegsitry.sol
@@ -15,6 +15,11 @@ contract MockDKIMRegsitry is IDKIMRegsitry {
         domainName;
         publicKeyHash;
 
+        // arbitary condition to mock invalid verification
+        if (publicKeyHash == keccak256(abi.encodePacked("return false"))) {
+            return false;
+        }
+
         return true;
     }
 }

--- a/account-integrations/safe/src/utils/MockDKIMRegsitry.sol
+++ b/account-integrations/safe/src/utils/MockDKIMRegsitry.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IDKIMRegsitry} from "../interface/IDKIMRegsitry.sol";
+
+// Mock/stub of DKIM Registry.
+//
+// This will eventually be removed in favor of real DKIM Registry.
+// https://github.com/getwax/wax/issues/171
+contract MockDKIMRegsitry is IDKIMRegsitry {
+    function isDKIMPublicKeyHashValid(
+        string memory domainName,
+        bytes32 publicKeyHash
+    ) public pure returns (bool) {
+        domainName;
+        publicKeyHash;
+
+        return true;
+    }
+}

--- a/account-integrations/safe/src/utils/MockGroth16Verifier.sol
+++ b/account-integrations/safe/src/utils/MockGroth16Verifier.sol
@@ -4,9 +4,9 @@ pragma abicoder v2;
 
 import {IGroth16Verifier} from "../interface/IGroth16Verifier.sol";
 
-// Mock/stub of snarkjs Groth16 Solidity verifier that always returns true.
-// We can't allow the result to change as that would break
-// ERC-4337 validation storage rules.
+// Mock/stub of snarkjs Groth16 Solidity verifier.
+// We can't allow the result to change via a flag in storage as
+// that would break ERC-4337 validation storage rules.
 //
 // This will eventually be removed in favor of real ZKP verfication contract.
 // https://github.com/getwax/wax/issues/143
@@ -16,6 +16,20 @@ contract MockGroth16Verifier is IGroth16Verifier {
         uint256[2][2] memory b,
         uint256[2] memory c,
         uint256[1] memory publicSignals
+    ) external pure returns (bool r) {
+        a;
+        b;
+        c;
+        publicSignals;
+
+        r = true;
+    }
+
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[4] memory publicSignals
     ) external pure returns (bool r) {
         a;
         b;

--- a/account-integrations/safe/src/utils/MockGroth16Verifier.sol
+++ b/account-integrations/safe/src/utils/MockGroth16Verifier.sol
@@ -37,7 +37,7 @@ contract MockGroth16Verifier is IGroth16Verifier {
         publicSignals;
 
         // arbitary condition to mock invalid verification
-        if (publicSignals[0] == 1) {
+        if (a[0] == 1) {
             return r = false;
         }
 

--- a/account-integrations/safe/src/utils/MockGroth16Verifier.sol
+++ b/account-integrations/safe/src/utils/MockGroth16Verifier.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
-import {IPasswordVerifier} from "../interface/IPasswordVerifier.sol";
+import {IGroth16Verifier} from "../interface/IGroth16Verifier.sol";
 
 // Mock/stub of snarkjs Groth16 Solidity verifier that always returns true.
 // We can't allow the result to change as that would break
@@ -10,7 +10,7 @@ import {IPasswordVerifier} from "../interface/IPasswordVerifier.sol";
 //
 // This will eventually be removed in favor of real ZKP verfication contract.
 // https://github.com/getwax/wax/issues/143
-contract MockPasswordVerifier is IPasswordVerifier {
+contract MockGroth16Verifier is IGroth16Verifier {
     function verifyProof(
         uint256[2] memory a,
         uint256[2][2] memory b,
@@ -21,6 +21,11 @@ contract MockPasswordVerifier is IPasswordVerifier {
         b;
         c;
         publicSignals;
+
+        // arbitary condition to mock invalid verification
+        if (publicSignals[0] == 1) {
+            return r = false;
+        }
 
         r = true;
     }

--- a/account-integrations/safe/src/utils/Safe4337Base.sol
+++ b/account-integrations/safe/src/utils/Safe4337Base.sol
@@ -7,14 +7,32 @@ import {HandlerContext} from "safe-contracts/contracts/handler/HandlerContext.so
 import {BaseAccount} from "account-abstraction/contracts/core/BaseAccount.sol";
 
 interface ISafe {
+    /**
+     * @notice Enables the module `module` for the Safe.
+     * @dev This can only be done via a Safe transaction.
+     * @param module Module to be enabled.
+     */
     function enableModule(address module) external;
 
+    /**
+     * @dev Allows a Module to execute a Safe transaction without any further confirmations.
+     * @param to Destination address of module transaction.
+     * @param value Ether value of module transaction.
+     * @param data Data payload of module transaction.
+     * @param operation Operation type of module transaction.
+     */
     function execTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,
         uint8 operation
     ) external returns (bool success);
+
+    /**
+     * @notice Returns if an module is enabled
+     * @return True if the module is enabled
+     */
+    function isModuleEnabled(address module) external view returns (bool);
 }
 
 /**
@@ -27,17 +45,17 @@ interface ISafe {
 abstract contract Safe4337Base is BaseAccount, HandlerContext {
     error NONCE_NOT_SEQUENTIAL();
 
-    function _requireFromEntryPoint() internal virtual view override {
+    function _requireFromEntryPoint() internal view virtual override {
         require(
             _msgSender() == address(entryPoint()),
             "account: not from EntryPoint"
         );
     }
 
-    function _requireFromCurrentSafeOrEntryPoint() internal virtual view {
+    function _requireFromCurrentSafeOrEntryPoint() internal view virtual {
         require(
             _msgSender() == address(entryPoint()) ||
-            _msgSender() == address(_currentSafe()),
+                _msgSender() == address(_currentSafe()),
             "account: not from EntryPoint nor current safe"
         );
     }
@@ -82,7 +100,7 @@ abstract contract Safe4337Base is BaseAccount, HandlerContext {
      * `this` will be the plugin for those calls, so it won't work when trying
      * to do safe operations like `execTransactionFromModule`.
      */
-    function _currentSafe() internal virtual view returns (ISafe) {
+    function _currentSafe() internal view virtual returns (ISafe) {
         return ISafe(msg.sender);
     }
 }

--- a/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
@@ -76,7 +76,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         salt = "test salt";
     }
 
-    function test_addRecoveryAccount_ModuleNotEnabled() public {
+    function test_addRecoveryHash_ModuleNotEnabled() public {
         // Arrange
         bytes32 recoveryHash = keccak256(
             abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
@@ -91,14 +91,14 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
 
         // Assert
         vm.expectRevert(SafeZkEmailRecoveryPlugin.MODULE_NOT_ENABLED.selector);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             safeAddress,
             address(safeECDSAPlugin)
         );
     }
 
-    function test_addRecoveryAccount_invalidOwner() public {
+    function test_addRecoveryHash_invalidOwner() public {
         // Arrange
         address invalidOwner = Dave.addr;
         bytes32 recoveryHash = keccak256(
@@ -114,14 +114,14 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
                 invalidOwner
             )
         );
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             invalidOwner,
             address(safeECDSAPlugin)
         );
     }
 
-    function test_addRecoveryAccount_recoveryAccountAdded() public {
+    function test_addRecoveryHash_recoveryAccountAdded() public {
         // Arrange
         bytes32 recoveryHash = keccak256(
             abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
@@ -129,7 +129,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
 
         // Act
         vm.startPrank(safeAddress);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             owner,
             address(safeECDSAPlugin)
@@ -143,7 +143,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         assertEq(zkEmailRecoveryStorage.recoveryHash, recoveryHash);
     }
 
-    function test_addRecoveryAccount_addMultipleRecoveryAccountsToSamePlugin()
+    function test_addRecoveryHash_addMultipleRecoveryAccountsToSamePlugin()
         public
     {
         // Arrange
@@ -182,14 +182,14 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
 
         // Act
         vm.startPrank(safeAddress);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash1,
             owner,
             address(safeECDSAPlugin)
         );
 
         vm.startPrank(safe2Address);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash2,
             owner,
             address(safeECDSAPlugin)
@@ -227,7 +227,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         );
 
         vm.startPrank(safeAddress);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             owner,
             address(safeECDSAPlugin)
@@ -274,7 +274,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         );
 
         vm.startPrank(safeAddress);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             owner,
             address(safeECDSAPlugin)
@@ -315,7 +315,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         );
 
         vm.startPrank(safeAddress);
-        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+        safeZkEmailRecoveryPlugin.addRecoveryHash(
             recoveryHash,
             owner,
             address(safeECDSAPlugin)

--- a/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import {TestHelper} from "./utils/TestHelper.sol";
+import {SafeZkEmailRecoveryPlugin, ZkEmailRecoveryStorage} from "../../src/SafeZkEmailRecoveryPlugin.sol";
+import {SafeECDSAPlugin} from "../../src/SafeECDSAPlugin.sol";
+import {MockGroth16Verifier} from "../../src/utils/MockGroth16Verifier.sol";
+import {Safe} from "safe-contracts/contracts/Safe.sol";
+import {SafeProxy} from "safe-contracts/contracts/proxies/SafeProxy.sol";
+import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+
+/* solhint-disable func-name-mixedcase */
+/* solhint-disable private-vars-leading-underscore */
+/* solhint-disable var-name-mixedcase */
+
+contract SafeZkEmailRecoveryPluginTest is TestHelper {
+    using ECDSA for bytes32;
+
+    constructor() TestHelper() {}
+
+    SafeZkEmailRecoveryPlugin public safeZkEmailRecoveryPlugin;
+    SafeECDSAPlugin public safeECDSAPlugin;
+    Safe public safeSingleton;
+    Safe public safe;
+    address public safeAddress;
+
+    address public owner;
+
+    bytes32 RECOVERY_HASH_DOMAIN;
+
+    function setUp() public {
+        MockGroth16Verifier mockGroth16Verifier = new MockGroth16Verifier();
+        safeZkEmailRecoveryPlugin = new SafeZkEmailRecoveryPlugin(
+            address(mockGroth16Verifier)
+        );
+        safeECDSAPlugin = new SafeECDSAPlugin(entryPointAddress);
+
+        safeSingleton = new Safe();
+        SafeProxy safeProxy = new SafeProxy(address(safeSingleton));
+
+        address[] memory owners = new address[](1);
+        owner = Alice.addr;
+        owners[0] = owner;
+
+        safe = Safe(payable(address(safeProxy)));
+        safeAddress = address(safe);
+
+        safe.setup(
+            owners,
+            1,
+            address(safeECDSAPlugin),
+            abi.encodeCall(SafeECDSAPlugin.enableMyself, (owner)),
+            address(safeECDSAPlugin),
+            address(0),
+            0,
+            payable(address(0))
+        );
+
+        vm.startPrank(safeAddress);
+        safe.enableModule(address(safeZkEmailRecoveryPlugin));
+        vm.stopPrank();
+
+        RECOVERY_HASH_DOMAIN = keccak256(
+            abi.encodePacked(
+                "RECOVERY_PLUGIN",
+                uint256(1),
+                block.chainid,
+                address(safeZkEmailRecoveryPlugin)
+            )
+        );
+    }
+
+    function test_addRecoveryAccount_ModuleNotEnabled() public {
+        // Arrange
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        address prevModuleInLinkedList = address(0x1);
+        address moduleToDisable = address(safeZkEmailRecoveryPlugin);
+
+        // Act
+        vm.startPrank(safeAddress);
+        safe.disableModule(prevModuleInLinkedList, moduleToDisable);
+
+        // Assert
+        vm.expectRevert(SafeZkEmailRecoveryPlugin.MODULE_NOT_ENABLED.selector);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            safeAddress,
+            address(safeECDSAPlugin)
+        );
+    }
+
+    function test_addRecoveryAccount_invalidOwner() public {
+        // Arrange
+        address invalidOwner = Dave.addr;
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        // Act & Assert
+        vm.startPrank(safeAddress);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeZkEmailRecoveryPlugin.INVALID_OWNER.selector,
+                owner,
+                invalidOwner
+            )
+        );
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            invalidOwner,
+            address(safeECDSAPlugin)
+        );
+    }
+
+    function test_addRecoveryAccount_recoveryAccountAdded() public {
+        // Arrange
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        // Act
+        vm.startPrank(safeAddress);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            owner,
+            address(safeECDSAPlugin)
+        );
+
+        ZkEmailRecoveryStorage
+            memory zkEmailRecoveryStorage = safeZkEmailRecoveryPlugin
+                .getZkEmailRecoveryStorage(safeAddress);
+
+        // Assert
+        assertEq(zkEmailRecoveryStorage.recoveryHash, recoveryHash);
+    }
+
+    function test_addRecoveryAccount_addMultipleRecoveryAccountsToSamePlugin()
+        public
+    {
+        // Arrange
+
+        // Create and setup second safe to use with plugin
+        SafeProxy safeProxy2 = new SafeProxy(address(safeSingleton));
+        Safe safe2 = Safe(payable(address(safeProxy2)));
+        address safe2Address = address(safe2);
+
+        address[] memory owners = new address[](1);
+        owners[0] = owner;
+
+        vm.startPrank(safe2Address);
+        safe2.setup(
+            owners,
+            1,
+            address(safeECDSAPlugin),
+            abi.encodeCall(SafeECDSAPlugin.enableMyself, (owner)),
+            address(safeECDSAPlugin),
+            address(0),
+            0,
+            payable(address(0))
+        );
+
+        safe2.enableModule(address(safeZkEmailRecoveryPlugin));
+        vm.stopPrank();
+
+        bytes32 email1 = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        bytes32 email2 = 0xdea89a4f4488c5f2e94b9fe37b1c17104c8b11442520b364fde514989c08c478; // ethers.keccak256(ethers.toUtf8Bytes("test2@mail.com"));
+        string memory salt = "test salt";
+
+        bytes32 guardianHash1 = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email1, salt)
+        );
+
+        bytes32 guardianHash2 = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email2, salt)
+        );
+
+        // Act
+        vm.startPrank(safeAddress);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            guardianHash1,
+            owner,
+            address(safeECDSAPlugin)
+        );
+
+        vm.startPrank(safe2Address);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            guardianHash2,
+            owner,
+            address(safeECDSAPlugin)
+        );
+
+        // Assert
+        ZkEmailRecoveryStorage
+            memory zkEmailRecoveryStorage = safeZkEmailRecoveryPlugin
+                .getZkEmailRecoveryStorage(safeAddress);
+        ZkEmailRecoveryStorage
+            memory ecdsaRecoveryStorage2 = safeZkEmailRecoveryPlugin
+                .getZkEmailRecoveryStorage(safe2Address);
+
+        assertEq(zkEmailRecoveryStorage.recoveryHash, guardianHash1);
+        assertEq(ecdsaRecoveryStorage2.recoveryHash, guardianHash2);
+    }
+
+    function test_resetEcdsaAddress_invalidRecoveryHash() public {
+        // Arrange
+        address recoveryAccount = Bob.addr;
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+        uint256[2] memory a = [uint256(0), uint256(0)];
+        uint256[2][2] memory b = [
+            [uint256(0), uint256(0)],
+            [uint256(0), uint256(0)]
+        ];
+        uint256[2] memory c = [uint256(0), uint256(0)];
+        uint256[1] memory publicSignals = [uint256(0)];
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked("INVALID_RECOVERY_HASH_DOMAIN", email, salt)
+        );
+
+        bytes32 expectedGuardianHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        vm.startPrank(safeAddress);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            owner,
+            address(safeECDSAPlugin)
+        );
+        vm.stopPrank();
+
+        Vm.Wallet memory newOwner = Carol;
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeZkEmailRecoveryPlugin.INVALID_GUARDIAN_HASH.selector,
+                recoveryHash,
+                expectedGuardianHash
+            )
+        );
+        safeZkEmailRecoveryPlugin.recoverAccount(
+            safeAddress,
+            address(safeECDSAPlugin),
+            newOwner.addr,
+            salt,
+            email,
+            a,
+            b,
+            c,
+            publicSignals
+        );
+    }
+
+    function test_resetEcdsaAddress_invalidProof() public {
+        // Arrange
+        address recoveryAccount = Bob.addr;
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+        uint256[2] memory a = [uint256(0), uint256(0)];
+        uint256[2][2] memory b = [
+            [uint256(0), uint256(0)],
+            [uint256(0), uint256(0)]
+        ];
+        uint256[2] memory c = [uint256(0), uint256(0)];
+        uint256[1] memory publicSignals = [uint256(1)]; // arbitary value that returns false from mock verifier
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        vm.startPrank(safeAddress);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            owner,
+            address(safeECDSAPlugin)
+        );
+        vm.stopPrank();
+
+        Vm.Wallet memory newOwner = Carol;
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(SafeZkEmailRecoveryPlugin.INVALID_PROOF.selector);
+        safeZkEmailRecoveryPlugin.recoverAccount(
+            safeAddress,
+            address(safeECDSAPlugin),
+            newOwner.addr,
+            salt,
+            email,
+            a,
+            b,
+            c,
+            publicSignals
+        );
+    }
+
+    function test_resetEcdsaAddress_resetsEcdsaAddress() public {
+        // Arrange
+        address recoveryAccount = Bob.addr;
+        bytes32 email = 0x6f1450935d03f8edb673952efc01207c5de7c9bffb123f23b79dbeb80a73376e; // ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+        string memory salt = "test salt";
+        uint256[2] memory a = [uint256(0), uint256(0)];
+        uint256[2][2] memory b = [
+            [uint256(0), uint256(0)],
+            [uint256(0), uint256(0)]
+        ];
+        uint256[2] memory c = [uint256(0), uint256(0)];
+        uint256[1] memory publicSignals = [uint256(0)];
+
+        bytes32 recoveryHash = keccak256(
+            abi.encodePacked(RECOVERY_HASH_DOMAIN, email, salt)
+        );
+
+        vm.startPrank(safeAddress);
+        safeZkEmailRecoveryPlugin.addRecoveryAccount(
+            recoveryHash,
+            owner,
+            address(safeECDSAPlugin)
+        );
+        vm.stopPrank();
+
+        Vm.Wallet memory newOwner = Carol;
+
+        // Act
+        vm.startPrank(recoveryAccount);
+        safeZkEmailRecoveryPlugin.recoverAccount(
+            safeAddress,
+            address(safeECDSAPlugin),
+            newOwner.addr,
+            salt,
+            email,
+            a,
+            b,
+            c,
+            publicSignals
+        );
+
+        // Assert
+        address updatedOwner = safeECDSAPlugin.getOwner(safeAddress);
+        assertEq(updatedOwner, newOwner.addr);
+    }
+}

--- a/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
@@ -5,7 +5,7 @@ import { resolveProperties, ethers } from "ethers";
 import sendUserOpAndWait from "./utils/sendUserOpAndWait";
 import receiptOf from "./utils/receiptOf";
 import {
-  MockPasswordVerifier__factory,
+  MockGroth16Verifier__factory,
   SafeZKPPasswordFactory__factory,
   SafeZKPPasswordPlugin__factory,
 } from "../../typechain-types";
@@ -35,7 +35,7 @@ describe("SafeZKPPasswordPlugin", () => {
     const signer = await provider.getSigner();
     // TODO (merge-ok) Use real verifier from zkp dir
     // https://github.com/getwax/wax/issues/143
-    const passwordVerifier = await new MockPasswordVerifier__factory(
+    const groth16Verifier = await new MockGroth16Verifier__factory(
       signer,
     ).deploy();
 
@@ -44,7 +44,7 @@ describe("SafeZKPPasswordPlugin", () => {
       entryPointAddress,
       owner.address,
       0,
-      passwordVerifier,
+      groth16Verifier,
     ] satisfies Parameters<typeof safeZKPPasswordFactory.create.staticCall>;
 
     const accountAddress = await safeZKPPasswordFactory.create.staticCall(

--- a/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
@@ -1,0 +1,413 @@
+import { expect } from "chai";
+import {
+  HDNodeWallet,
+  JsonRpcProvider,
+  NonceManager,
+  ethers,
+  getBytes,
+} from "ethers";
+
+import { executeContractCallWithSigners } from "./utils/execution";
+import SafeSingletonFactory from "./utils/SafeSingletonFactory";
+import {
+  MockGroth16Verifier__factory,
+  Safe,
+  SafeECDSAFactory__factory,
+  SafeECDSAPlugin__factory,
+  SafeZkEmailRecoveryPlugin,
+  SafeZkEmailRecoveryPlugin__factory,
+  Safe__factory,
+  SimpleAccountFactory__factory,
+  SimpleAccount__factory,
+} from "../../typechain-types";
+import receiptOf from "./utils/receiptOf";
+import { setupTests } from "./utils/setupTests";
+import { createAndSendUserOpWithEcdsaSig } from "./utils/createUserOp";
+
+describe("SafeECDSARecoveryPlugin", () => {
+  let bundlerProvider: JsonRpcProvider;
+  let provider: JsonRpcProvider;
+  let admin: NonceManager;
+  let owner: HDNodeWallet;
+  let entryPointAddress: string;
+  let safeSingleton: Safe;
+  let ssf: SafeSingletonFactory;
+
+  let safeProxyAddress: string;
+  let recoveryPlugin: SafeZkEmailRecoveryPlugin;
+  let guardianSigner: HDNodeWallet;
+
+  beforeEach(async () => {
+    const setup = await setupTests();
+    ({
+      provider,
+      bundlerProvider,
+      admin,
+      owner,
+      entryPointAddress,
+      ssf,
+      safeSingleton,
+    } = setup);
+
+    const safeECDSAFactory = await ssf.connectOrDeploy(
+      SafeECDSAFactory__factory,
+      [],
+    );
+    await safeECDSAFactory.waitForDeployment();
+
+    const createArgs = [
+      safeSingleton,
+      entryPointAddress,
+      owner.address,
+      0,
+    ] satisfies Parameters<typeof safeECDSAFactory.create.staticCall>;
+
+    safeProxyAddress = await safeECDSAFactory.create.staticCall(...createArgs);
+
+    await receiptOf(safeECDSAFactory.create(...createArgs));
+
+    // Native tokens for the pre-fund
+    await receiptOf(
+      admin.sendTransaction({
+        to: safeProxyAddress,
+        value: ethers.parseEther("10"),
+      }),
+    );
+
+    const mockGroth16Verifier = await ssf.connectOrDeploy(
+      MockGroth16Verifier__factory,
+      [],
+    );
+
+    recoveryPlugin = await ssf.connectOrDeploy(
+      SafeZkEmailRecoveryPlugin__factory,
+      [await mockGroth16Verifier.getAddress()],
+    );
+    await recoveryPlugin.waitForDeployment();
+
+    guardianSigner = ethers.Wallet.createRandom(provider);
+    await receiptOf(
+      admin.sendTransaction({
+        to: guardianSigner.address,
+        value: ethers.parseEther("1"),
+      }),
+    );
+  });
+
+  it("Should use recovery plugin via EOA and then send tx with new key.", async () => {
+    const recoveryPluginAddress = await recoveryPlugin.getAddress();
+    const safe = Safe__factory.connect(safeProxyAddress, owner);
+
+    // Enable recovery plugin
+    await receiptOf(
+      executeContractCallWithSigners(
+        safe,
+        safe,
+        "enableModule",
+        [recoveryPluginAddress],
+        // @ts-expect-error owner doesn't have all properties for some reason
+        [owner],
+      ),
+    );
+
+    // Construct userOp to add recovery account
+    const chainId = (await provider.getNetwork()).chainId;
+
+    const email = ethers.keccak256(ethers.toUtf8Bytes("test2@mail.com"));
+    const salt = "test salt";
+
+    const recoveryhashDomain = ethers.solidityPackedKeccak256(
+      ["string", "uint256", "uint256", "address"],
+      ["RECOVERY_PLUGIN", 1, chainId, recoveryPluginAddress],
+    );
+
+    const recoveryHash = ethers.solidityPackedKeccak256(
+      ["bytes32", "bytes32", "string"],
+      [recoveryhashDomain, email, salt],
+    );
+
+    const safeProxyWithEcdsaPluginInterface = SafeECDSAPlugin__factory.connect(
+      safeProxyAddress,
+      provider,
+    );
+    const safeECDSAPluginAddress =
+      await safeProxyWithEcdsaPluginInterface.myAddress();
+
+    const addRecoveryAccountCalldata =
+      recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
+        recoveryHash,
+        owner.address,
+        safeECDSAPluginAddress,
+      ]);
+
+    let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
+      safeProxyAddress,
+      owner,
+    );
+
+    let userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
+      "execTransaction",
+      [await recoveryPlugin.getAddress(), "0x00", addRecoveryAccountCalldata],
+    );
+
+    const initCode = "0x";
+    const dummySignature = await owner.signMessage("dummy sig");
+
+    // Send userOp to add recovery account
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      owner,
+      safeProxyAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    const storedRecoveryHash =
+      await recoveryPlugin.zkEmailRecoveryStorage(safeProxyAddress);
+    expect(recoveryHash).to.equal(storedRecoveryHash);
+
+    // Construct tx to reset ecdsa address
+    const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
+    const currentOwnerHash = ethers.solidityPackedKeccak256(
+      ["address"],
+      [owner.address],
+    );
+
+    const a: [bigint, bigint] = [BigInt(0), BigInt(0)];
+    const b: [[bigint, bigint], [bigint, bigint]] = [
+      [BigInt(0), BigInt(0)],
+      [BigInt(0), BigInt(0)],
+    ];
+    const c: [bigint, bigint] = [BigInt(0), BigInt(0)];
+    const publicSignals: [bigint] = [BigInt(0)];
+
+    const recoverAccountArgs = [
+      safeProxyAddress,
+      safeECDSAPluginAddress,
+      newEcdsaPluginSigner.address,
+      salt,
+      email,
+      a,
+      b,
+      c,
+      publicSignals,
+    ] satisfies Parameters<typeof recoveryPlugin.recoverAccount.staticCall>;
+
+    await recoveryPlugin
+      .connect(guardianSigner)
+      .recoverAccount.staticCall(...recoverAccountArgs);
+
+    // Send tx to reset ecdsa address
+    await receiptOf(
+      recoveryPlugin
+        .connect(guardianSigner)
+        .recoverAccount(...recoverAccountArgs),
+    );
+
+    const newOwner = await safeEcdsaPlugin.ecdsaOwnerStorage(safeProxyAddress);
+    expect(newOwner).to.equal(newEcdsaPluginSigner.address);
+
+    // Send userOp with new owner
+    const recipientAddress = ethers.Wallet.createRandom().address;
+    const transferAmount = ethers.parseEther("1");
+    userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
+      "execTransaction",
+      [recipientAddress, transferAmount, "0x00"],
+    );
+
+    const recipientBalanceBefore = await provider.getBalance(recipientAddress);
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      newEcdsaPluginSigner,
+      safeProxyAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    const recipientBalanceAfter = await provider.getBalance(recipientAddress);
+    const expectedRecipientBalance = recipientBalanceBefore + transferAmount;
+    expect(recipientBalanceAfter).to.equal(expectedRecipientBalance);
+  });
+
+  it("Should use recovery plugin via smart account and then send tx with new key.", async () => {
+    const recoveryPluginAddress = await recoveryPlugin.getAddress();
+    const guardianAddress = guardianSigner.address;
+    const safe = Safe__factory.connect(safeProxyAddress, owner);
+
+    // Enable recovery plugin
+    await receiptOf(
+      executeContractCallWithSigners(
+        safe,
+        safe,
+        "enableModule",
+        [recoveryPluginAddress],
+        // @ts-expect-error owner doesn't have all properties for some reason
+        [owner],
+      ),
+    );
+
+    // Deploy guardian smart account
+    const simpleAccountFactory = await ssf.connectOrDeploy(
+      SimpleAccountFactory__factory,
+      [entryPointAddress],
+    );
+    const guardianSimpleAccountAddress =
+      await simpleAccountFactory.createAccount.staticCall(guardianAddress, 0);
+
+    await receiptOf(simpleAccountFactory.createAccount(guardianAddress, 0));
+
+    // Construct userOp to add recovery account
+    const chainId = (await provider.getNetwork()).chainId;
+    const email = ethers.keccak256(ethers.toUtf8Bytes("test@mail.com"));
+    const salt = "test salt";
+
+    const recoveryhashDomain = ethers.solidityPackedKeccak256(
+      ["string", "uint256", "uint256", "address"],
+      ["RECOVERY_PLUGIN", 1, chainId, recoveryPluginAddress],
+    );
+
+    const recoveryHash = ethers.solidityPackedKeccak256(
+      ["bytes32", "bytes32", "string"],
+      [recoveryhashDomain, email, salt],
+    );
+
+    const safeProxyWithEcdsaPluginInterface = SafeECDSAPlugin__factory.connect(
+      safeProxyAddress,
+      provider,
+    );
+    const safeECDSAPluginAddress =
+      await safeProxyWithEcdsaPluginInterface.myAddress();
+
+    const addRecoveryAccountCalldata =
+      recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
+        recoveryHash,
+        owner.address,
+        safeECDSAPluginAddress,
+      ]);
+
+    let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
+      safeProxyAddress,
+      owner,
+    );
+
+    let userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
+      "execTransaction",
+      [await recoveryPlugin.getAddress(), "0x00", addRecoveryAccountCalldata],
+    );
+
+    const initCode = "0x";
+    const dummySignature = await owner.signMessage("dummy sig");
+
+    // Send userOp to add recovery account
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      owner,
+      safeProxyAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    const storedRecoveryHash =
+      await recoveryPlugin.zkEmailRecoveryStorage(safeProxyAddress);
+    expect(recoveryHash).to.equal(storedRecoveryHash);
+
+    // Construct userOp to reset ecdsa address
+    const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
+    const currentOwnerHash = ethers.solidityPackedKeccak256(
+      ["address"],
+      [owner.address],
+    );
+    const addressSignature = await newEcdsaPluginSigner.signMessage(
+      getBytes(currentOwnerHash),
+    );
+
+    const a: [bigint, bigint] = [BigInt(0), BigInt(0)];
+    const b: [[bigint, bigint], [bigint, bigint]] = [
+      [BigInt(0), BigInt(0)],
+      [BigInt(0), BigInt(0)],
+    ];
+    const c: [bigint, bigint] = [BigInt(0), BigInt(0)];
+    const publicSignals: [bigint] = [BigInt(0)];
+
+    const recoverAccountCalldata = recoveryPlugin.interface.encodeFunctionData(
+      "recoverAccount",
+      [
+        safeProxyAddress,
+        safeECDSAPluginAddress,
+        newEcdsaPluginSigner.address,
+        salt,
+        email,
+        a,
+        b,
+        c,
+        publicSignals,
+      ],
+    );
+
+    const simpleAccount = SimpleAccount__factory.createInterface();
+    userOpCallData = simpleAccount.encodeFunctionData("execute", [
+      await recoveryPlugin.getAddress(),
+      "0x00",
+      recoverAccountCalldata,
+    ]);
+
+    // Native tokens for the pre-fund
+    await receiptOf(
+      admin.sendTransaction({
+        to: guardianSimpleAccountAddress,
+        value: ethers.parseEther("10"),
+      }),
+    );
+
+    // Send userOp to reset ecdsa address
+    // Note: Failing with an unrecognised custom error when attempting to first construct
+    // the init code and pass it into the recovery user op, so deploying account
+    // first and using empty init code here
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      guardianSigner,
+      guardianSimpleAccountAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    const newOwner = await safeEcdsaPlugin.ecdsaOwnerStorage(safeProxyAddress);
+    expect(newOwner).to.equal(newEcdsaPluginSigner.address);
+
+    // Send userOp with new owner
+    const recipientAddress = ethers.Wallet.createRandom().address;
+    const transferAmount = ethers.parseEther("1");
+    userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
+      "execTransaction",
+      [recipientAddress, transferAmount, "0x00"],
+    );
+
+    const recipientBalanceBefore = await provider.getBalance(recipientAddress);
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      newEcdsaPluginSigner,
+      safeProxyAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    const recipientBalanceAfter = await provider.getBalance(recipientAddress);
+    const expectedRecipientBalance = recipientBalanceBefore + transferAmount;
+    expect(recipientBalanceAfter).to.equal(expectedRecipientBalance);
+  });
+});

--- a/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
@@ -121,12 +121,10 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     const safeECDSAPluginAddress =
       await safeProxyWithEcdsaPluginInterface.myAddress();
 
-    const addRecoveryAccountCalldata =
-      recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
-        recoveryHash,
-        ownerAddress,
-        safeECDSAPluginAddress,
-      ]);
+    const addRecoveryHashCalldata = recoveryPlugin.interface.encodeFunctionData(
+      "addRecoveryHash",
+      [recoveryHash, ownerAddress, safeECDSAPluginAddress],
+    );
 
     let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
       safeProxyAddress,
@@ -135,7 +133,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
 
     let userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
       "execTransaction",
-      [await recoveryPlugin.getAddress(), "0x00", addRecoveryAccountCalldata],
+      [await recoveryPlugin.getAddress(), "0x00", addRecoveryHashCalldata],
     );
 
     const initCode = "0x";
@@ -278,12 +276,10 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     const safeECDSAPluginAddress =
       await safeProxyWithEcdsaPluginInterface.myAddress();
 
-    const addRecoveryAccountCalldata =
-      recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
-        recoveryHash,
-        ownerAddress,
-        safeECDSAPluginAddress,
-      ]);
+    const addRecoveryHashCalldata = recoveryPlugin.interface.encodeFunctionData(
+      "addRecoveryHash",
+      [recoveryHash, ownerAddress, safeECDSAPluginAddress],
+    );
 
     let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
       safeProxyAddress,
@@ -292,7 +288,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
 
     let userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
       "execTransaction",
-      [await recoveryPlugin.getAddress(), "0x00", addRecoveryAccountCalldata],
+      [await recoveryPlugin.getAddress(), "0x00", addRecoveryHashCalldata],
     );
 
     const initCode = "0x";

--- a/account-integrations/safe/test/hardhat/utils/createUserOp.ts
+++ b/account-integrations/safe/test/hardhat/utils/createUserOp.ts
@@ -1,4 +1,4 @@
-import { ethers, getBytes, HDNodeWallet, NonceManager } from "ethers";
+import { ethers, getBytes, HDNodeWallet, NonceManager, Signer } from "ethers";
 import { AddressZero } from "@ethersproject/constants";
 import { UserOperationStruct } from "@account-abstraction/contracts";
 import { getUserOpHash } from "@account-abstraction/utils";
@@ -131,7 +131,7 @@ export const createUserOperation = async (
 export const createAndSendUserOpWithEcdsaSig = async (
   provider: ethers.JsonRpcProvider,
   bundlerProvider: ethers.JsonRpcProvider,
-  owner: HDNodeWallet,
+  owner: Signer,
   accountAddress: string,
   initCode: string,
   userOpCallData: string,

--- a/account-integrations/safe/test/hardhat/utils/setupTests.ts
+++ b/account-integrations/safe/test/hardhat/utils/setupTests.ts
@@ -26,13 +26,14 @@ export async function setupTests() {
   const provider = new ethers.JsonRpcProvider(NODE_URL);
   await makeDevFaster(provider);
 
-  const [, signer] = getSigners();
+  const [, signer, otherSigner] = getSigners();
   const admin = new NonceManager(signer.connect(provider));
   const owner = ethers.Wallet.createRandom(provider);
+  const otherAccount = new NonceManager(otherSigner.connect(provider));
 
   await receiptOf(
     await admin.sendTransaction({
-      to: owner.address,
+      to: await owner.getAddress(),
       value: ethers.parseEther("1"),
     }),
   );
@@ -61,6 +62,7 @@ export async function setupTests() {
     provider,
     admin,
     owner,
+    otherAccount,
     entryPointAddress,
     ssf,
     safeProxyFactory,


### PR DESCRIPTION
## What is this PR doing?
- Adds a zk email recovery plugin
- Adds forge and hardhat tests
- Mocks external components not developed yet (uses existing mock verifier)

The recovery flow is based off of the existing ecdsa recovery plugin flow. This flow will likely change in the future but serves as a goos starting point to get the zk email plugin off the ground.

## How can these changes be manually tested?
Run `SafeZkEmailRecoveryPlugin.test.ts`

## Does this PR resolve or contribute to any issues?
resolves #167 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
