### PR TITLE
Add default and custom delay to zkemail recovery

### DIFF
--- a/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
@@ -217,7 +217,6 @@ contract SafeZkEmailRecoveryPlugin {
         bool verified = verifier.verifyProof(a, b, c, publicSignals);
         if (!verified) revert INVALID_PROOF();
 
-        // FIXME: if recovery is not configured, should not get here
         uint256 executeAfter = block.timestamp + recoveryDelay[safe];
 
         recoveryRequests[safe].executeAfter = executeAfter;

--- a/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
+++ b/account-integrations/safe/src/SafeZkEmailRecoveryPlugin.sol
@@ -42,6 +42,7 @@ contract SafeZkEmailRecoveryPlugin {
     error MODULE_NOT_ENABLED();
     error INVALID_OWNER(address expectedOwner, address owner);
     error RECOVERY_ALREADY_INITIATED();
+    error RECOVERY_NOT_CONFIGURED();
     error INVALID_DKIM_KEY_HASH(
         address safe,
         string emailDomain,
@@ -182,6 +183,10 @@ contract SafeZkEmailRecoveryPlugin {
         uint256[2] memory c
     ) external {
         RecoveryRequest memory recoveryRequest = recoveryRequests[safe];
+
+        if (recoveryRequest.recoveryHash == bytes32(0)) {
+            revert RECOVERY_NOT_CONFIGURED();
+        }
 
         if (recoveryRequest.executeAfter > 0) {
             revert RECOVERY_ALREADY_INITIATED();

--- a/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
@@ -387,6 +387,33 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         assertEq(recoveryRequest2.pendingNewOwner, address(0));
     }
 
+    function test_initiateRecovery_recoveryNotConfigured() public {
+        // Arrange
+        address recoveryAccount = Bob.addr;
+        uint256[2] memory a = [uint256(0), uint256(0)];
+        uint256[2][2] memory b = [
+            [uint256(0), uint256(0)],
+            [uint256(0), uint256(0)]
+        ];
+        uint256[2] memory c = [uint256(0), uint256(0)];
+
+        Vm.Wallet memory newOwner = Carol;
+
+        // Act & Assert
+        vm.startPrank(recoveryAccount);
+        vm.expectRevert(
+            SafeZkEmailRecoveryPlugin.RECOVERY_NOT_CONFIGURED.selector
+        );
+        safeZkEmailRecoveryPlugin.initiateRecovery(
+            safeAddress,
+            newOwner.addr,
+            emailDomain,
+            a,
+            b,
+            c
+        );
+    }
+
     function test_initiateRecovery_recoveryAlreadyInitiated() public {
         // Arrange
         address recoveryAccount = Bob.addr;

--- a/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeZkEmailRecoveryPlugin.t.sol
@@ -243,7 +243,9 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
 
         // Assert
         assertEq(recoveryRequest.recoveryHash, recoveryHash);
-        // FIXME: update assertions
+        assertEq(recoveryRequest.dkimPublicKeyHash, dkimPublicKeyHash);
+        assertEq(recoveryRequest.executeAfter, 0);
+        assertEq(recoveryRequest.pendingNewOwner, address(0));
     }
 
     function test_configureRecovery_addMultipleRecoveryAccountsToSamePlugin()
@@ -310,8 +312,14 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
             .getRecoveryRequest(safe2Address);
 
         assertEq(recoveryRequest1.recoveryHash, recoveryHash1);
+        assertEq(recoveryRequest1.dkimPublicKeyHash, dkimPublicKeyHash);
+        assertEq(recoveryRequest1.executeAfter, 0);
+        assertEq(recoveryRequest1.pendingNewOwner, address(0));
+
         assertEq(recoveryRequest2.recoveryHash, recoveryHash2);
-        // FIXME: update assertions
+        assertEq(recoveryRequest2.dkimPublicKeyHash, dkimPublicKeyHash);
+        assertEq(recoveryRequest2.executeAfter, 0);
+        assertEq(recoveryRequest2.pendingNewOwner, address(0));
     }
 
     function test_initiateRecovery_recoveryAlreadyInitiated() public {
@@ -764,7 +772,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
 
         assertEq(recoveryRequestAfter.recoveryHash, bytes32(0));
         assertEq(recoveryRequestAfter.dkimPublicKeyHash, bytes32(0));
-        assertEq(recoveryRequestAfter.executeAfter, uint256(0));
+        assertEq(recoveryRequestAfter.executeAfter, 0);
         assertEq(recoveryRequestAfter.pendingNewOwner, address(0));
     }
 }

--- a/account-integrations/safe/test/hardhat/SafeCompressionPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeCompressionPlugin.test.ts
@@ -43,7 +43,7 @@ describe("SafeCompressionPlugin", () => {
       safeSingleton,
       entryPointAddress,
       await fallbackDecompressor.getAddress(),
-      owner.address,
+      await owner.getAddress(),
       0,
     ] satisfies Parameters<typeof safeCompressionFactory.create.staticCall>;
 

--- a/account-integrations/safe/test/hardhat/SafeECDSAPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSAPlugin.test.ts
@@ -35,7 +35,7 @@ describe("SafeECDSAPlugin", () => {
     const createArgs = [
       safeSingleton,
       entryPointAddress,
-      owner.address,
+      await owner.getAddress(),
       0,
     ] satisfies Parameters<typeof safeECDSAFactory.create.staticCall>;
 
@@ -97,7 +97,7 @@ describe("SafeECDSAPlugin", () => {
     const createArgs = [
       safeSingleton,
       entryPointAddress,
-      owner.address,
+      await owner.getAddress(),
       0,
     ] satisfies Parameters<typeof safeECDSAFactory.create.staticCall>;
 

--- a/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
@@ -27,7 +27,7 @@ describe("SafeECDSARecoveryPlugin", () => {
   let bundlerProvider: JsonRpcProvider;
   let provider: JsonRpcProvider;
   let admin: NonceManager;
-  let owner: HDNodeWallet;
+  let owner: NonceManager;
   let entryPointAddress: string;
   let safeSingleton: Safe;
   let ssf: SafeSingletonFactory;
@@ -57,7 +57,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     const createArgs = [
       safeSingleton,
       entryPointAddress,
-      owner.address,
+      await owner.getAddress(),
       0,
     ] satisfies Parameters<typeof safeECDSAFactory.create.staticCall>;
 
@@ -143,7 +143,7 @@ describe("SafeECDSARecoveryPlugin", () => {
 
     const recoveryHash = ethers.solidityPackedKeccak256(
       ["bytes32", "address", "address", "string"],
-      [recoveryhashDomain, guardianAddress, owner.address, salt],
+      [recoveryhashDomain, guardianAddress, await owner.getAddress(), salt],
     );
 
     const safeProxyWithEcdsaPluginInterface = SafeECDSAPlugin__factory.connect(
@@ -156,7 +156,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     const addRecoveryAccountCalldata =
       recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
         recoveryHash,
-        owner.address,
+        await owner.getAddress(),
         safeECDSAPluginAddress,
       ]);
 
@@ -193,7 +193,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
     const currentOwnerHash = ethers.solidityPackedKeccak256(
       ["address"],
-      [owner.address],
+      [await owner.getAddress()],
     );
     const addressSignature = await newEcdsaPluginSigner.signMessage(
       getBytes(currentOwnerHash),
@@ -204,7 +204,7 @@ describe("SafeECDSARecoveryPlugin", () => {
       safeProxyAddress,
       salt,
       safeECDSAPluginAddress,
-      owner.address,
+      await owner.getAddress(),
       newEcdsaPluginSigner.address,
     ] satisfies Parameters<typeof recoveryPlugin.resetEcdsaAddress.staticCall>;
 
@@ -285,7 +285,12 @@ describe("SafeECDSARecoveryPlugin", () => {
 
     const recoveryHash = ethers.solidityPackedKeccak256(
       ["bytes32", "address", "address", "string"],
-      [recoveryhashDomain, guardianSimpleAccountAddress, owner.address, salt],
+      [
+        recoveryhashDomain,
+        guardianSimpleAccountAddress,
+        await owner.getAddress(),
+        salt,
+      ],
     );
 
     const safeProxyWithEcdsaPluginInterface = SafeECDSAPlugin__factory.connect(
@@ -298,7 +303,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     const addRecoveryAccountCalldata =
       recoveryPlugin.interface.encodeFunctionData("addRecoveryAccount", [
         recoveryHash,
-        owner.address,
+        await owner.getAddress(),
         safeECDSAPluginAddress,
       ]);
 
@@ -335,7 +340,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
     const currentOwnerHash = ethers.solidityPackedKeccak256(
       ["address"],
-      [owner.address],
+      [await owner.getAddress()],
     );
     const addressSignature = await newEcdsaPluginSigner.signMessage(
       getBytes(currentOwnerHash),
@@ -347,7 +352,7 @@ describe("SafeECDSARecoveryPlugin", () => {
         safeProxyAddress,
         salt,
         safeECDSAPluginAddress,
-        owner.address,
+        await owner.getAddress(),
         newEcdsaPluginSigner.address,
       ]);
 

--- a/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
@@ -42,7 +42,7 @@ describe("SafeZKPPasswordPlugin", () => {
     const createArgs = [
       safeSingleton,
       entryPointAddress,
-      owner.address,
+      await owner.getAddress(),
       0,
       groth16Verifier,
     ] satisfies Parameters<typeof safeZKPPasswordFactory.create.staticCall>;

--- a/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
@@ -149,16 +149,14 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     );
     const dkimRegistryAddress = await mockDkimRegistry.getAddress();
 
-    const addRecoveryHashCalldata = recoveryPlugin.interface.encodeFunctionData(
-      "addRecoveryHash",
-      [
+    const configureRecoveryCalldata =
+      recoveryPlugin.interface.encodeFunctionData("configureRecovery", [
         safeECDSAPluginAddress,
         ownerAddress,
         recoveryHash,
         dkimPublicKeyHash,
         dkimRegistryAddress,
-      ],
-    );
+      ]);
 
     let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
       safeProxyAddress,
@@ -167,7 +165,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
 
     let userOpCallData = safeEcdsaPlugin.interface.encodeFunctionData(
       "execTransaction",
-      [await recoveryPlugin.getAddress(), "0x00", addRecoveryHashCalldata],
+      [await recoveryPlugin.getAddress(), "0x00", configureRecoveryCalldata],
     );
 
     const initCode = "0x";
@@ -185,13 +183,15 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       dummySignature,
     );
 
-    const recoveryStorage =
-      await recoveryPlugin.zkEmailRecoveryStorage(safeProxyAddress);
-    expect(recoveryHash).to.equal(recoveryStorage[0]);
-    expect(dkimPublicKeyHash).to.equal(recoveryStorage[1]);
+    const recoveryRequest =
+      await recoveryPlugin.recoveryRequests(safeProxyAddress);
+    expect(recoveryRequest[0]).to.equal(recoveryHash);
+    expect(recoveryRequest[1]).to.equal(dkimPublicKeyHash);
 
     // Construct tx to reset ecdsa address
-    const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
+    const newEcdsaPluginSigner = new NonceManager(
+      ethers.Wallet.createRandom().connect(provider),
+    );
     await receiptOf(
       await admin.sendTransaction({
         to: await newEcdsaPluginSigner.getAddress(),
@@ -208,29 +208,69 @@ describe("SafeZkEmailRecoveryPlugin", () => {
 
     const emailDomain = "google.com";
 
-    const recoverAccountArgs = [
+    // set custom delay
+    const oneSecond = 1;
+    await receiptOf(
+      executeContractCallWithSigners(
+        safe,
+        recoveryPlugin,
+        "setCustomDelay",
+        [oneSecond],
+        // @ts-expect-error owner doesn't have all properties for some reason
+        [owner],
+      ),
+    );
+
+    const initiateRecoveryArgs = [
       safeProxyAddress,
-      safeECDSAPluginAddress,
-      newEcdsaPluginSigner.address,
+      await newEcdsaPluginSigner.getAddress(),
       emailDomain,
       a,
       b,
       c,
-    ] satisfies Parameters<typeof recoveryPlugin.recoverAccount.staticCall>;
+    ] satisfies Parameters<typeof recoveryPlugin.initiateRecovery.staticCall>;
+
+    await recoveryPlugin
+      .connect(owner)
+      .initiateRecovery.staticCall(...initiateRecoveryArgs);
+
+    // initiate recovery process
+    await receiptOf(
+      recoveryPlugin.connect(owner).initiateRecovery(...initiateRecoveryArgs),
+    );
+
+    // send two transactions to progress time enough for delay
+    await receiptOf(
+      admin.sendTransaction({
+        to: ethers.Wallet.createRandom().address,
+        value: ethers.parseEther("1"),
+      }),
+    );
+    await receiptOf(
+      admin.sendTransaction({
+        to: ethers.Wallet.createRandom().address,
+        value: ethers.parseEther("1"),
+      }),
+    );
+
+    const recoverPluginArgs = [
+      safeProxyAddress,
+      await safeEcdsaPlugin.myAddress(),
+    ] satisfies Parameters<typeof recoveryPlugin.recoverPlugin.staticCall>;
 
     await recoveryPlugin
       .connect(newEcdsaPluginSigner)
-      .recoverAccount.staticCall(...recoverAccountArgs);
+      .recoverPlugin.staticCall(...recoverPluginArgs);
 
     // Send tx to reset ecdsa address
     await receiptOf(
       recoveryPlugin
         .connect(newEcdsaPluginSigner)
-        .recoverAccount(...recoverAccountArgs),
+        .recoverPlugin(...recoverPluginArgs),
     );
 
     const newOwner = await safeEcdsaPlugin.ecdsaOwnerStorage(safeProxyAddress);
-    expect(newOwner).to.equal(newEcdsaPluginSigner.address);
+    expect(newOwner).to.equal(await newEcdsaPluginSigner.getAddress());
 
     // Send userOp with new owner
     const recipientAddress = ethers.Wallet.createRandom().address;
@@ -326,7 +366,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     const dkimRegistryAddress = await mockDkimRegistry.getAddress();
 
     const addRecoveryHashCalldata = recoveryPlugin.interface.encodeFunctionData(
-      "addRecoveryHash",
+      "configureRecovery",
       [
         safeECDSAPluginAddress,
         ownerAddress,
@@ -361,10 +401,10 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       dummySignature,
     );
 
-    const recoveryStorage =
-      await recoveryPlugin.zkEmailRecoveryStorage(safeProxyAddress);
-    expect(recoveryHash).to.equal(recoveryStorage[0]);
-    expect(dkimPublicKeyHash).to.equal(recoveryStorage[1]);
+    const recoveryRequest =
+      await recoveryPlugin.recoveryRequests(safeProxyAddress);
+    expect(recoveryRequest[0]).to.equal(recoveryHash);
+    expect(recoveryRequest[1]).to.equal(dkimPublicKeyHash);
 
     // Construct userOp to reset ecdsa address
     const newEcdsaPluginSigner = ethers.Wallet.createRandom().connect(provider);
@@ -377,24 +417,34 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     const c: [bigint, bigint] = [BigInt(0), BigInt(0)];
     const emailDomain = "google.com";
 
-    const recoverAccountCalldata = recoveryPlugin.interface.encodeFunctionData(
-      "recoverAccount",
-      [
+    // set custom delay
+    const oneSecond = 1;
+    await receiptOf(
+      executeContractCallWithSigners(
+        safe,
+        recoveryPlugin,
+        "setCustomDelay",
+        [oneSecond],
+        // @ts-expect-error owner doesn't have all properties for some reason
+        [owner],
+      ),
+    );
+
+    const initiateRecoveryCalldata =
+      recoveryPlugin.interface.encodeFunctionData("initiateRecovery", [
         safeProxyAddress,
-        safeECDSAPluginAddress,
-        newEcdsaPluginSigner.address,
+        await newEcdsaPluginSigner.getAddress(),
         emailDomain,
         a,
         b,
         c,
-      ],
-    );
+      ]);
 
     const simpleAccount = SimpleAccount__factory.createInterface();
     userOpCallData = simpleAccount.encodeFunctionData("execute", [
       await recoveryPlugin.getAddress(),
       "0x00",
-      recoverAccountCalldata,
+      initiateRecoveryCalldata,
     ]);
 
     // Native tokens for the pre-fund
@@ -405,10 +455,47 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       }),
     );
 
-    // Send userOp to reset ecdsa address
+    // Send userOp to initiate the recovery process
     // Note: Failing with an unrecognised custom error when attempting to first construct
     // the init code and pass it into the recovery user op, so deploying account
     // first and using empty init code here
+    await createAndSendUserOpWithEcdsaSig(
+      provider,
+      bundlerProvider,
+      otherAccount,
+      otherSimpleAccountAddress,
+      initCode,
+      userOpCallData,
+      entryPointAddress,
+      dummySignature,
+    );
+
+    // send two transactions to progress time enough for delay
+    await receiptOf(
+      admin.sendTransaction({
+        to: ethers.Wallet.createRandom().address,
+        value: ethers.parseEther("1"),
+      }),
+    );
+    await receiptOf(
+      admin.sendTransaction({
+        to: ethers.Wallet.createRandom().address,
+        value: ethers.parseEther("1"),
+      }),
+    );
+
+    const recoverAccountCalldata = recoveryPlugin.interface.encodeFunctionData(
+      "recoverPlugin",
+      [safeProxyAddress, safeECDSAPluginAddress],
+    );
+
+    userOpCallData = simpleAccount.encodeFunctionData("execute", [
+      await recoveryPlugin.getAddress(),
+      "0x00",
+      recoverAccountCalldata,
+    ]);
+
+    // Send userOp to recover plugin
     await createAndSendUserOpWithEcdsaSig(
       provider,
       bundlerProvider,

--- a/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
@@ -148,6 +148,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       [dkimPublicKey],
     );
     const dkimRegistryAddress = await mockDkimRegistry.getAddress();
+    const zeroSeconds = 0;
 
     const configureRecoveryCalldata =
       recoveryPlugin.interface.encodeFunctionData("configureRecovery", [
@@ -156,6 +157,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
         recoveryHash,
         dkimPublicKeyHash,
         dkimRegistryAddress,
+        zeroSeconds,
       ]);
 
     let safeEcdsaPlugin = SafeECDSAPlugin__factory.connect(
@@ -214,7 +216,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       executeContractCallWithSigners(
         safe,
         recoveryPlugin,
-        "setCustomDelay",
+        "setRecoveryDelay",
         [oneSecond],
         // @ts-expect-error owner doesn't have all properties for some reason
         [owner],
@@ -364,6 +366,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       [dkimPublicKey],
     );
     const dkimRegistryAddress = await mockDkimRegistry.getAddress();
+    const zeroSeconds = 0;
 
     const addRecoveryHashCalldata = recoveryPlugin.interface.encodeFunctionData(
       "configureRecovery",
@@ -373,6 +376,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
         recoveryHash,
         dkimPublicKeyHash,
         dkimRegistryAddress,
+        zeroSeconds,
       ],
     );
 
@@ -423,7 +427,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       executeContractCallWithSigners(
         safe,
         recoveryPlugin,
-        "setCustomDelay",
+        "setRecoveryDelay",
         [oneSecond],
         // @ts-expect-error owner doesn't have all properties for some reason
         [owner],

--- a/account-integrations/safe/test/hardhat/utils/createUserOp.ts
+++ b/account-integrations/safe/test/hardhat/utils/createUserOp.ts
@@ -19,7 +19,7 @@ type Plugin = SafeBlsPlugin | SafeWebAuthnPlugin;
 
 export const generateInitCodeAndAddress = async (
   admin: NonceManager,
-  owner: ethers.HDNodeWallet,
+  owner: NonceManager,
   plugin: Plugin,
   safeSingleton: Safe,
   safeProxyFactory: SafeProxyFactory,
@@ -32,7 +32,7 @@ export const generateInitCodeAndAddress = async (
   const encodedInitializer = safeSingleton.interface.encodeFunctionData(
     "setup",
     [
-      [owner.address],
+      [await owner.getAddress()],
       1,
       pluginAddress,
       moduleInitializer,

--- a/account-integrations/safe/test/hardhat/utils/execution.ts
+++ b/account-integrations/safe/test/hardhat/utils/execution.ts
@@ -1,14 +1,14 @@
 // Note: most of this code is copied from https://github.com/safe-global/safe-contracts with
 // small modifications to work with Hardhat ethers.
 
-import { Contract, Wallet, BigNumberish, Signer } from "ethers";
+import { Contract, Wallet, BigNumberish, Signer, BaseContract } from "ethers";
 import { TypedDataSigner } from "@ethersproject/abstract-signer";
 import { AddressZero } from "@ethersproject/constants";
 import { Safe } from "../../../typechain-types";
 
 export const executeContractCallWithSigners = async (
   safe: Safe,
-  contract: Safe,
+  contract: BaseContract,
   method: string,
   params: any[],
   signers: Wallet[],
@@ -27,14 +27,13 @@ export const executeContractCallWithSigners = async (
 };
 
 export const buildContractCall = async (
-  contract: Safe,
+  contract: BaseContract,
   method: string,
   params: any[],
   nonce: number,
   delegateCall?: boolean,
   overrides?: Partial<SafeTransaction>,
 ): Promise<SafeTransaction> => {
-  // @ts-expect-error Copying this function for testing purposes. TS error is irrelevant.
   const data = contract.interface.encodeFunctionData(method, params);
   return buildSafeTransaction(
     Object.assign(

--- a/account-integrations/safe/test/hardhat/utils/setupTests.ts
+++ b/account-integrations/safe/test/hardhat/utils/setupTests.ts
@@ -28,7 +28,7 @@ export async function setupTests() {
 
   const [, signer, otherSigner] = getSigners();
   const admin = new NonceManager(signer.connect(provider));
-  const owner = ethers.Wallet.createRandom(provider);
+  const owner = new NonceManager(ethers.Wallet.createRandom(provider));
   const otherAccount = new NonceManager(otherSigner.connect(provider));
 
   await receiptOf(


### PR DESCRIPTION
## What is this PR doing?
- Adds a default delay of 2 weeks for recovery
- Adds a configurable custom delay for recovery which overrides the default delay
- Adds a cancel recovery function. Access control for this function relies on the fact that msg.sender is the safe for which recovery should be cancelled for. We may want to add more robust access control in future work.

### Basic flow
3 functions now need to be called in the recovery plugin to successfully rotate an owner on the ecsda plugin: `configureRecovery`, `initiateRecovery` & `recoverPlugin`. Also `setCustomDelay` if setting a custom delay.

- `configureRecovery` (previously called `addRecoveryHash`) largely does what it did before, which is storing a recovery request in the form of a `recoveryHash` and a `dkimPublicKeyHash` (other values not set on the struct until later). Designed to be called by the safe via use of msg.sender
- `initiateRecovery` starts the recovery process and verifies the zkp required to recover the account. `executeAfter` and `pendingNewOwner` are then set as part of the recovery request. The account can then be recovered after the delay has passed. Currently designed to be called by anyone as long as the proof and other arguments are valid.
- `recoverPlugin` can be called by anyone and executes the recovery if the delay has elapsed. This function and also `initiateRecovery` replaced the previous function that executed recovery called `recoverAccount`.

### Why do we need a default delay _AND_ a custom delay?
A default delay provides an initial sensible default that follows best practises. This value should aim to provide users with a delay that provides them enough time to react to malicious/accidental recoveries, while not being too long as to leave them waiting for a long time before they can use their account again. However, different individuals/organisations may have differing requirements that mean a value such as 48 hours is far too long for the low value stored in the account. Alternatively, 48 hours may be too short to account for time spent on holiday/away from work. A custom delay allows the end user to specify a delay that works best for their own security and context.

Note: The default delay has been set to a high value of 2 weeks on purpose which might not be classed as a _sensible_ default. This is because we want developers who use our code to understand it and configure it to suit their specific context, as opposed to blindly copying and pasting (based off of learnings from other PSE projects). 

## How can these changes be manually tested?
Run integration tests

## Does this PR resolve or contribute to any issues?
#181

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
