### PR TITLE
BLS plugin: use aggregation

### DIFF
--- a/account-integrations/safe/.vscode/settings.json
+++ b/account-integrations/safe/.vscode/settings.json
@@ -3,7 +3,7 @@
   "solidity.packageDefaultDependenciesDirectory": "lib",
   "editor.rulers": [80],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.rules.customizations": [
     {

--- a/account-integrations/safe/script/deploy_all.ts
+++ b/account-integrations/safe/script/deploy_all.ts
@@ -28,7 +28,6 @@ async function deploy() {
 
   const contractFactories = [
     SimulateTxAccessor__factory,
-    SafeProxyFactory__factory,
     TokenCallbackHandler__factory,
     CompatibilityFallbackHandler__factory,
     CreateCall__factory,
@@ -36,8 +35,6 @@ async function deploy() {
     MultiSend__factory,
     MultiSendCallOnly__factory,
     SignMessageLib__factory,
-    SafeL2__factory,
-    Safe__factory,
     BLSOpen__factory,
     DeterministicDeployer.link(BLSSignatureAggregator__factory, [
       {
@@ -49,6 +46,21 @@ async function deploy() {
 
   for (const contractFactory of contractFactories) {
     const contract = await deployer.connectOrDeploy(contractFactory, []);
+
+    const contractName = contractFactory.name.split("_")[0];
+    console.log(`deployed ${contractName} to ${await contract.getAddress()}`);
+  }
+
+  const safeDeployer = await DeterministicDeployer.initSafeVersion(wallet);
+
+  const safeContractFactories = [
+    SafeProxyFactory__factory,
+    SafeL2__factory,
+    Safe__factory,
+  ];
+
+  for (const contractFactory of safeContractFactories) {
+    const contract = await safeDeployer.connectOrDeploy(contractFactory, []);
 
     const contractName = contractFactory.name.split("_")[0];
     console.log(`deployed ${contractName} to ${await contract.getAddress()}`);

--- a/account-integrations/safe/script/deploy_all.ts
+++ b/account-integrations/safe/script/deploy_all.ts
@@ -12,10 +12,20 @@ import {
   SafeL2__factory,
   Safe__factory,
   EntryPoint__factory,
+  BLSSignatureAggregator__factory,
+  BLSOpen__factory,
 } from "../typechain-types";
 import makeDevFaster from "../test/hardhat/utils/makeDevFaster";
 
 async function deploy() {
+  const { NODE_URL, MNEMONIC } = process.env;
+  const provider = new ethers.JsonRpcProvider(NODE_URL);
+  await makeDevFaster(provider);
+  const hdNode = ethers.HDNodeWallet.fromPhrase(MNEMONIC!);
+  const wallet = new ethers.Wallet(hdNode.privateKey, provider);
+
+  const safeSingletonFactory = await SafeSingletonFactory.init(wallet);
+
   const contractFactories = [
     SimulateTxAccessor__factory,
     SafeProxyFactory__factory,
@@ -28,15 +38,15 @@ async function deploy() {
     SignMessageLib__factory,
     SafeL2__factory,
     Safe__factory,
+    BLSOpen__factory,
+    SafeSingletonFactory.link(BLSSignatureAggregator__factory, [
+      {
+        "lib/account-abstraction/contracts/samples/bls/lib/BLSOpen.sol:BLSOpen":
+          safeSingletonFactory.calculateAddress(BLSOpen__factory, []),
+      },
+    ]),
   ];
 
-  const { NODE_URL, MNEMONIC } = process.env;
-  const provider = new ethers.JsonRpcProvider(NODE_URL);
-  await makeDevFaster(provider);
-  const hdNode = ethers.HDNodeWallet.fromPhrase(MNEMONIC!);
-  const wallet = new ethers.Wallet(hdNode.privateKey, provider);
-
-  const safeSingletonFactory = await SafeSingletonFactory.init(wallet);
   for (const contractFactory of contractFactories) {
     const contract = await safeSingletonFactory.connectOrDeploy(
       contractFactory,

--- a/account-integrations/safe/script/patched-bundler-727838b.dockerfile
+++ b/account-integrations/safe/script/patched-bundler-727838b.dockerfile
@@ -1,0 +1,16 @@
+FROM accountabstraction/bundler:0.6.2
+
+RUN apt-get update && \
+    apt-get install -y coreutils && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG EXPECTED_DIGEST="727838bd8705dd319970fb4a86c9abe5334e17312230143e01043abf0732b5f7"
+
+# Modify /app/bundler.js to add support for estimating (but not running) aggregate bundles
+RUN sed -i 's/(errorResult.errorName !== '\''ValidationResult'\'')/(!errorResult.errorName.startsWith('\''ValidationResult'\''))/g' /app/bundler.js
+
+# Fail if we didn't achieve the expected SHA256 digest
+RUN if [ "$(sha256sum /app/bundler.js | awk '{print $1}')" != "$EXPECTED_DIGEST" ]; then \
+    echo "SHA256 digest does not match. Aborting."; \
+    exit 1; \
+fi

--- a/account-integrations/safe/script/start.sh
+++ b/account-integrations/safe/script/start.sh
@@ -81,7 +81,7 @@ yarn hardhat run "${SCRIPT_DIR}/deploy_all.ts" --network localhost
 # Start ERC-4337 bundler
 docker pull ${BUNDLER_IMAGE}
 
-docker run --rm -i --name ${BUNDLER_CONTAINER} -p 3000:3000 -v ./config:/app/workdir:ro --network=${DOCKER_NETWORK} ${BUNDLER_IMAGE} \
+docker run --rm -i --name ${BUNDLER_CONTAINER} -p 3000:3000 -v "$PWD"/config:/app/workdir:ro --network=${DOCKER_NETWORK} ${BUNDLER_IMAGE} \
   --network http://${GETH_CONTAINER}:8545 \
   &
 

--- a/account-integrations/safe/src/imports.sol
+++ b/account-integrations/safe/src/imports.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.7.0 <0.9.0;
+
+import {BLSSignatureAggregator} from "account-abstraction/contracts/samples/bls/BLSSignatureAggregator.sol";

--- a/account-integrations/safe/test/forge/SafeBlsPlugin.t.sol
+++ b/account-integrations/safe/test/forge/SafeBlsPlugin.t.sol
@@ -8,18 +8,24 @@ import {SafeBlsPluginHarness} from "./utils/SafeBlsPluginHarness.sol";
 import {SafeBlsPlugin} from "../../src/SafeBlsPlugin.sol";
 import {Safe4337Base} from "../../src/utils/Safe4337Base.sol";
 import {UserOperation, UserOperationLib} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {BLSSignatureAggregator} from "account-abstraction/contracts/samples/bls/BLSSignatureAggregator.sol";
 
 /* solhint-disable func-name-mixedcase */
 
 contract SafeBlsPluginTest is TestHelper {
     constructor() TestHelper() {}
 
+    BLSSignatureAggregator public blsSignatureAggregator;
     SafeBlsPluginHarness public safeBlsPlugin;
 
     function setUp() public {
         uint256[4] memory blsPublicKey = getBlsPublicKey();
+
+        blsSignatureAggregator = new BLSSignatureAggregator();
+
         safeBlsPlugin = new SafeBlsPluginHarness(
             entryPointAddress,
+            address(blsSignatureAggregator),
             blsPublicKey
         );
     }

--- a/account-integrations/safe/test/forge/utils/SafeBlsPluginHarness.sol
+++ b/account-integrations/safe/test/forge/utils/SafeBlsPluginHarness.sol
@@ -8,8 +8,9 @@ import {SafeBlsPlugin} from "../../../src/SafeBlsPlugin.sol";
 contract SafeBlsPluginHarness is SafeBlsPlugin {
     constructor(
         address entryPointAddress,
+        address aggregatorAddress,
         uint256[4] memory blsPublicKey
-    ) SafeBlsPlugin(entryPointAddress, blsPublicKey) {}
+    ) SafeBlsPlugin(entryPointAddress, aggregatorAddress, blsPublicKey) {}
 
     function exposed_validateNonce(uint256 nonce) external view {
         _validateNonce(nonce);

--- a/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
@@ -25,7 +25,7 @@ describe("SafeBlsPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeProxyFactory,
       safeSingleton,
     } = await setupTests();
@@ -35,10 +35,10 @@ describe("SafeBlsPlugin", () => {
     const signerFactory = await hubbleBlsSigner.BlsSignerFactory.new();
     const blsSigner = signerFactory.getSigner(domain, BLS_PRIVATE_KEY);
 
-    const safeBlsPlugin = await ssf.connectOrDeploy(SafeBlsPlugin__factory, [
-      entryPointAddress,
-      blsSigner.pubkey,
-    ]);
+    const safeBlsPlugin = await deployer.connectOrDeploy(
+      SafeBlsPlugin__factory,
+      [entryPointAddress, blsSigner.pubkey],
+    );
 
     // Construct userOp
     const [, , signer] = getSigners();

--- a/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
@@ -16,6 +16,7 @@ import {
 import { getSigners } from "./utils/getSigners";
 import DeterministicDeployer from "./utils/DeterministicDeployer";
 import getBlsUserOpHash from "./utils/getBlsUserOpHash";
+import appendKeyToInitCode from "./utils/appendKeyToInitCode";
 
 const BLS_PRIVATE_KEY =
   "0xdbe3d601b1b25c42c50015a87855fdce00ea9b3a7e33c92d31c69aeb70708e08";
@@ -52,7 +53,6 @@ describe("SafeBlsPlugin", () => {
       [],
     );
 
-    // TODO: Revise aggregator staking
     await receiptOf(
       blsSignatureAggregator.addStake(entryPointAddress, 100n * 86_400n, {
         value: ethers.parseEther("1"),
@@ -86,8 +86,7 @@ describe("SafeBlsPlugin", () => {
       safeProxyFactory,
     );
 
-    // TODO: Explain (and revise?)
-    initCode += blsSigner.pubkey.map((w) => w.slice(2)).join("");
+    initCode = appendKeyToInitCode(initCode, blsSigner.pubkey);
 
     const unsignedUserOperation = await createUserOperation(
       provider,

--- a/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeBlsPlugin.test.ts
@@ -14,7 +14,6 @@ import {
   createUserOperation,
 } from "./utils/createUserOp";
 import { getSigners } from "./utils/getSigners";
-// import sendUserOpAndWait from "./utils/sendUserOpAndWait";
 import DeterministicDeployer from "./utils/DeterministicDeployer";
 import getBlsUserOpHash from "./utils/getBlsUserOpHash";
 
@@ -125,6 +124,11 @@ describe("SafeBlsPlugin", () => {
 
     const recipientBalanceBefore = await provider.getBalance(recipientAddress);
 
+    // TODO: Ideally we would use the bundler here via `sendUserOpAndWait`.
+    // However, eth-infinitism's bundler doesn't appear to have any support for
+    // sending aggregated bundles, since handleAggregatedOps does not appear in
+    // its code.
+
     // Send userOp
     const receipt = await receiptOf(
       entryPoint.connect(admin).handleAggregatedOps(
@@ -138,14 +142,6 @@ describe("SafeBlsPlugin", () => {
         await admin.getAddress(),
       ),
     );
-
-    // TODO: Send via bundler (previously dependent on #138, now failing for
-    //         different reason)
-    // await sendUserOpAndWait(
-    //   { ...userOperation, signature: "0x" },
-    //   entryPointAddress,
-    //   bundlerProvider,
-    // );
 
     await entryPoint.getUserOpHash(userOperation);
 

--- a/account-integrations/safe/test/hardhat/SafeCompressionPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeCompressionPlugin.test.ts
@@ -18,23 +18,23 @@ describe("SafeCompressionPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeSingleton,
     } = await setupTests();
 
     // Deploy compression contracts and compression plugin
-    const safeCompressionFactory = await ssf.connectOrDeploy(
+    const safeCompressionFactory = await deployer.connectOrDeploy(
       SafeCompressionFactory__factory,
       [],
     );
     await safeCompressionFactory.waitForDeployment();
 
-    const addressRegistry = await ssf.connectOrDeploy(
+    const addressRegistry = await deployer.connectOrDeploy(
       AddressRegistry__factory,
       [],
     );
 
-    const fallbackDecompressor = await ssf.connectOrDeploy(
+    const fallbackDecompressor = await deployer.connectOrDeploy(
       FallbackDecompressor__factory,
       [await addressRegistry.getAddress()],
     );

--- a/account-integrations/safe/test/hardhat/SafeECDSAPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSAPlugin.test.ts
@@ -18,7 +18,7 @@ describe("SafeECDSAPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeSingleton,
     } = await setupTests();
 
@@ -27,7 +27,7 @@ describe("SafeECDSAPlugin", () => {
     const dummySignature = await owner.signMessage("dummy sig");
 
     // Deploy ecdsa plugin
-    const safeECDSAFactory = await ssf.connectOrDeploy(
+    const safeECDSAFactory = await deployer.connectOrDeploy(
       SafeECDSAFactory__factory,
       [],
     );
@@ -86,10 +86,16 @@ describe("SafeECDSAPlugin", () => {
   });
 
   it("should not allow execTransaction from unrelated address", async () => {
-    const { provider, admin, owner, entryPointAddress, ssf, safeSingleton } =
-      await setupTests();
+    const {
+      provider,
+      admin,
+      owner,
+      entryPointAddress,
+      deployer,
+      safeSingleton,
+    } = await setupTests();
 
-    const safeECDSAFactory = await ssf.connectOrDeploy(
+    const safeECDSAFactory = await deployer.connectOrDeploy(
       SafeECDSAFactory__factory,
       [],
     );

--- a/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeECDSARecoveryPlugin.test.ts
@@ -8,7 +8,7 @@ import {
 } from "ethers";
 
 import { executeContractCallWithSigners } from "./utils/execution";
-import SafeSingletonFactory from "./utils/SafeSingletonFactory";
+import DeterministicDeployer from "./utils/DeterministicDeployer";
 import {
   Safe,
   SafeECDSAFactory__factory,
@@ -30,7 +30,7 @@ describe("SafeECDSARecoveryPlugin", () => {
   let owner: NonceManager;
   let entryPointAddress: string;
   let safeSingleton: Safe;
-  let ssf: SafeSingletonFactory;
+  let deployer: DeterministicDeployer;
 
   let safeProxyAddress: string;
   let recoveryPlugin: SafeECDSARecoveryPlugin;
@@ -44,11 +44,11 @@ describe("SafeECDSARecoveryPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeSingleton,
     } = setup);
 
-    const safeECDSAFactory = await ssf.connectOrDeploy(
+    const safeECDSAFactory = await deployer.connectOrDeploy(
       SafeECDSAFactory__factory,
       [],
     );
@@ -73,7 +73,7 @@ describe("SafeECDSARecoveryPlugin", () => {
       }),
     );
 
-    recoveryPlugin = await ssf.connectOrDeploy(
+    recoveryPlugin = await deployer.connectOrDeploy(
       SafeECDSARecoveryPlugin__factory,
       [],
     );
@@ -265,7 +265,7 @@ describe("SafeECDSARecoveryPlugin", () => {
     );
 
     // Deploy guardian smart account
-    const simpleAccountFactory = await ssf.connectOrDeploy(
+    const simpleAccountFactory = await deployer.connectOrDeploy(
       SimpleAccountFactory__factory,
       [entryPointAddress],
     );

--- a/account-integrations/safe/test/hardhat/SafeWebAuthnPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeWebAuthnPlugin.test.ts
@@ -69,14 +69,14 @@ describe("SafeWebAuthnPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeProxyFactory,
       safeSingleton,
     } = await setupTests();
     const { publicKey, userOpSignature } = getPublicKeyAndSignature();
 
     // Deploy webauthn plugin
-    const safeWebAuthnPlugin = await ssf.connectOrDeploy(
+    const safeWebAuthnPlugin = await deployer.connectOrDeploy(
       SafeWebAuthnPlugin__factory,
       [entryPointAddress, publicKey],
     );

--- a/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZKPPasswordPlugin.test.ts
@@ -20,14 +20,14 @@ describe("SafeZKPPasswordPlugin", () => {
       admin,
       owner,
       entryPointAddress,
-      ssf,
+      deployer,
       safeSingleton,
     } = await setupTests();
 
     const zkpClient = await ERC4337ZKPPasswordClient.create();
 
     // Deploy zk password plugin
-    const safeZKPPasswordFactory = await ssf.connectOrDeploy(
+    const safeZKPPasswordFactory = await deployer.connectOrDeploy(
       SafeZKPPasswordFactory__factory,
       [],
     );

--- a/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
+++ b/account-integrations/safe/test/hardhat/SafeZkEmailRecoveryPlugin.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { JsonRpcProvider, NonceManager, Signer, ethers } from "ethers";
 
 import { executeContractCallWithSigners } from "./utils/execution";
-import SafeSingletonFactory from "./utils/SafeSingletonFactory";
+import DeterministicDeployer from "./utils/DeterministicDeployer";
 import {
   MockDKIMRegsitry,
   MockDKIMRegsitry__factory,
@@ -29,7 +29,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
   let entryPointAddress: string;
   let safeSingleton: Safe;
   let mockDkimRegistry: MockDKIMRegsitry;
-  let ssf: SafeSingletonFactory;
+  let deployer: DeterministicDeployer;
 
   let safeProxyAddress: string;
   let recoveryPlugin: SafeZkEmailRecoveryPlugin;
@@ -43,11 +43,11 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       owner,
       otherAccount,
       entryPointAddress,
-      ssf,
+      deployer,
       safeSingleton,
     } = setup);
 
-    const safeECDSAFactory = await ssf.connectOrDeploy(
+    const safeECDSAFactory = await deployer.connectOrDeploy(
       SafeECDSAFactory__factory,
       [],
     );
@@ -72,19 +72,22 @@ describe("SafeZkEmailRecoveryPlugin", () => {
       }),
     );
 
-    const mockGroth16Verifier = await ssf.connectOrDeploy(
+    const mockGroth16Verifier = await deployer.connectOrDeploy(
       MockGroth16Verifier__factory,
       [],
     );
 
-    const defaultDkimRegistry = await ssf.connectOrDeploy(
+    const defaultDkimRegistry = await deployer.connectOrDeploy(
       MockDKIMRegsitry__factory,
       [],
     );
 
-    mockDkimRegistry = await ssf.connectOrDeploy(MockDKIMRegsitry__factory, []);
+    mockDkimRegistry = await deployer.connectOrDeploy(
+      MockDKIMRegsitry__factory,
+      [],
+    );
 
-    recoveryPlugin = await ssf.connectOrDeploy(
+    recoveryPlugin = await deployer.connectOrDeploy(
       SafeZkEmailRecoveryPlugin__factory,
       [
         await mockGroth16Verifier.getAddress(),
@@ -318,7 +321,7 @@ describe("SafeZkEmailRecoveryPlugin", () => {
     );
 
     // Deploy guardian smart account
-    const simpleAccountFactory = await ssf.connectOrDeploy(
+    const simpleAccountFactory = await deployer.connectOrDeploy(
       SimpleAccountFactory__factory,
       [entryPointAddress],
     );

--- a/account-integrations/safe/test/hardhat/utils/DeterministicDeployer.ts
+++ b/account-integrations/safe/test/hardhat/utils/DeterministicDeployer.ts
@@ -44,8 +44,6 @@ type Deployment = {
  * ensure constructor arguments are correct.
  */
 export default class DeterministicDeployer {
-  static address = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
-
   static deployment = {
     transaction: [
       "0x",
@@ -58,6 +56,7 @@ export default class DeterministicDeployer {
     gasPrice: 100_000_000_000n, // 100 gwei
     gasLimit: 100_000n,
     signerAddress: "0x3fab184622dc19b6109349b94811493bf2a45362",
+    address: "0x4e59b44847b379578588920ca78fbf26c0b4956c",
   };
 
   provider: ethers.Provider;
@@ -83,7 +82,7 @@ export default class DeterministicDeployer {
 
     const { chainId } = await provider.getNetwork();
 
-    const address = DeterministicDeployer.address;
+    const address = DeterministicDeployer.deployment.address;
 
     const existingCode = await provider.getCode(address);
 
@@ -103,13 +102,16 @@ export default class DeterministicDeployer {
 
     await (await provider.broadcastTransaction(deployment.transaction)).wait();
 
-    const deployedCode = await provider.getCode(DeterministicDeployer.address);
+    const deployedCode = await provider.getCode(
+      DeterministicDeployer.deployment.address,
+    );
+
     assert(deployedCode !== "0x", "Failed to deploy safe singleton factory");
 
     return new DeterministicDeployer(
       signer,
       chainId,
-      DeterministicDeployer.address,
+      DeterministicDeployer.deployment.address,
     );
   }
 
@@ -317,7 +319,7 @@ export class DeterministicDeploymentViewer {
     public signerOrProvider: SignerOrProvider,
     public chainId: bigint,
   ) {
-    this.safeSingletonFactoryAddress = DeterministicDeployer.address;
+    this.safeSingletonFactoryAddress = DeterministicDeployer.deployment.address;
 
     let provider: ethers.Provider | undefined;
 

--- a/account-integrations/safe/test/hardhat/utils/DeterministicDeployer.ts
+++ b/account-integrations/safe/test/hardhat/utils/DeterministicDeployer.ts
@@ -77,7 +77,11 @@ export default class DeterministicDeployer {
 
     this.provider = signer.provider;
 
-    this.viewer = new DeterministicDeploymentViewer(signer, chainId);
+    this.viewer = new DeterministicDeploymentViewer(
+      signer,
+      chainId,
+      deployment.address,
+    );
   }
 
   static async init(
@@ -455,6 +459,8 @@ export class DeterministicDeploymentViewer {
       signerOrProvider,
       safeDeployerAddress,
     );
+
+    return viewer;
   }
 
   calculateAddress<CFC extends ContractFactoryConstructor>(

--- a/account-integrations/safe/test/hardhat/utils/SafeSingletonFactory.ts
+++ b/account-integrations/safe/test/hardhat/utils/SafeSingletonFactory.ts
@@ -137,6 +137,19 @@ export default class SafeSingletonFactory {
     return await SafeSingletonFactory.init(signerOrFactory);
   }
 
+  // TODO: Explain
+  static link<CFC extends ContractFactoryConstructor>(
+    ContractFactoryConstructor: CFC,
+    constructorParams: ConstructorParameters<CFC>,
+  ): CFC {
+    return class LinkedCFC extends (ContractFactoryConstructor as any) {
+      constructor() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        super(...constructorParams);
+      }
+    } as CFC;
+  }
+
   calculateAddress<CFC extends ContractFactoryConstructor>(
     ContractFactoryConstructor: CFC,
     deployParams: DeployParams<CFC>,

--- a/account-integrations/safe/test/hardhat/utils/appendKeyToInitCode.ts
+++ b/account-integrations/safe/test/hardhat/utils/appendKeyToInitCode.ts
@@ -1,0 +1,42 @@
+import { solG2 } from "@thehubbleproject/bls/dist/mcl";
+import { ethers } from "ethers";
+
+/**
+ * Appends the public key to the init code.
+ *
+ * In handleAggregatedOps, the EntryPoint has the aggregator check the bundle
+ * before any accounts are created via initCode. This means the aggregator needs
+ * a way to know the public key of the account without it being deployed, and it
+ * uses the last 4 words of the initCode to do this:
+ * https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/bls/BLSSignatureAggregator.sol#L22-L34
+ *
+ * Usually this could be sensibly built into the account's regular initCode
+ * because it's a necessary ingredient of creating the account, but because
+ * we're using safe plugins, the public key is in the separately-created safe
+ * plugin and the account is tied to it via the safe plugin's address.
+ *
+ * We can work around this by simply appending the public key to the regular
+ * initCode, because the solidity ABI generally ignores extraneous data.
+ *
+ * A key ingredient for making this secure is that, once created, our account
+ * will check that the trailing bytes of the initCode (if present), matches its
+ * public key. Otherwise, because our account's address doesn't depend on these
+ * trailing bytes an attacker could instantiate our account on another network
+ * together with a malicious first operation of their choosing. They would
+ * simply generate their own bls key pair and modify our first user-op from
+ * another network, replacing the trailing bytes of the initCode with their
+ * public key, changing the calldata to perform an operation of their choice,
+ * and updating the signature. This means any assets transferred to us on
+ * a network we haven't started using could be stolen.
+ */
+export default function appendKeyToInitCode(
+  initCode: string,
+  blsPublicKey: solG2,
+) {
+  return (
+    initCode +
+    ethers.AbiCoder.defaultAbiCoder()
+      .encode(["uint256[4]"], [blsPublicKey])
+      .slice(2)
+  );
+}

--- a/account-integrations/safe/test/hardhat/utils/getBlsUserOpHash.ts
+++ b/account-integrations/safe/test/hardhat/utils/getBlsUserOpHash.ts
@@ -1,0 +1,60 @@
+import { ethers, keccak256 } from "ethers";
+import { ResolvedUserOp } from "./resolveUserOp";
+import { solG2 } from "@thehubbleproject/bls/dist/mcl";
+
+export default function getBlsUserOpHash(
+  chainId: bigint,
+  aggregatorAddress: string,
+  publicKey: solG2,
+  userOp: ResolvedUserOp,
+): string {
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+
+  const publicKeyHash = keccak256(abi.encode(["uint256[4]"], [publicKey]));
+
+  return keccak256(
+    abi.encode(
+      ["bytes32", "bytes32", "address", "uint256"],
+      [internalUserOpHash(userOp), publicKeyHash, aggregatorAddress, chainId],
+    ),
+  );
+}
+
+/**
+ * Replicates the internalUserOpHash function in BLSSignatureAggregator.sol.
+ *
+ * (Also the same as UserOperationLib.hash, but *different* from EntryPoint's
+ * getUserOpHash and BLSSignatureAggregator's getUserOpHash.)
+ */
+function internalUserOpHash(userOp: ResolvedUserOp): string {
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+
+  return keccak256(
+    abi.encode(
+      [
+        "address", // userOp.sender,
+        "uint256", // userOp.nonce,
+        "bytes32", // keccak256(userOp.initCode),
+        "bytes32", // keccak256(userOp.callData),
+        "uint256", // userOp.callGasLimit,
+        "uint256", // userOp.verificationGasLimit,
+        "uint256", // userOp.preVerificationGas,
+        "uint256", // userOp.maxFeePerGas,
+        "uint256", // userOp.maxPriorityFeePerGas,
+        "bytes32", // keccak256(userOp.paymasterAndData),
+      ],
+      [
+        userOp.sender,
+        userOp.nonce,
+        keccak256(userOp.initCode),
+        keccak256(userOp.callData),
+        userOp.callGasLimit,
+        userOp.verificationGasLimit,
+        userOp.preVerificationGas,
+        userOp.maxFeePerGas,
+        userOp.maxPriorityFeePerGas,
+        keccak256(userOp.paymasterAndData),
+      ],
+    ),
+  );
+}

--- a/account-integrations/safe/test/hardhat/utils/resolveUserOp.ts
+++ b/account-integrations/safe/test/hardhat/utils/resolveUserOp.ts
@@ -1,0 +1,23 @@
+import { UserOperationStruct } from "@account-abstraction/contracts";
+
+export default async function resolveUserOp(
+  userOp: UserOperationStruct,
+): Promise<ResolvedUserOp> {
+  return {
+    sender: await userOp.sender,
+    nonce: await userOp.nonce,
+    initCode: await userOp.initCode,
+    callData: await userOp.callData,
+    callGasLimit: await userOp.callGasLimit,
+    verificationGasLimit: await userOp.verificationGasLimit,
+    preVerificationGas: await userOp.preVerificationGas,
+    maxFeePerGas: await userOp.maxFeePerGas,
+    maxPriorityFeePerGas: await userOp.maxPriorityFeePerGas,
+    paymasterAndData: await userOp.paymasterAndData,
+    signature: await userOp.signature,
+  };
+}
+
+export type ResolvedUserOp = {
+  [K in keyof UserOperationStruct]: Awaited<UserOperationStruct[K]>;
+};

--- a/account-integrations/safe/test/hardhat/utils/setupTests.ts
+++ b/account-integrations/safe/test/hardhat/utils/setupTests.ts
@@ -49,13 +49,15 @@ export async function setupTests() {
 
   const entryPointAddress = entryPoints[0];
 
-  const deployer = await DeterministicDeployer.init(admin);
+  const safeDeployer = await DeterministicDeployer.initSafeVersion(admin);
 
-  const safeProxyFactory = await deployer.connectOrDeploy(
+  const safeProxyFactory = await safeDeployer.connectOrDeploy(
     SafeProxyFactory__factory,
     [],
   );
-  const safeSingleton = await deployer.connectOrDeploy(Safe__factory, []);
+  const safeSingleton = await safeDeployer.connectOrDeploy(Safe__factory, []);
+
+  const deployer = await DeterministicDeployer.init(admin);
 
   return {
     bundlerProvider,
@@ -64,7 +66,7 @@ export async function setupTests() {
     owner,
     otherAccount,
     entryPointAddress,
-    deployer: deployer,
+    deployer,
     safeProxyFactory,
     safeSingleton,
   };

--- a/account-integrations/safe/test/hardhat/utils/setupTests.ts
+++ b/account-integrations/safe/test/hardhat/utils/setupTests.ts
@@ -3,7 +3,7 @@ import {
   SafeProxyFactory__factory,
   Safe__factory,
 } from "../../../typechain-types";
-import SafeSingletonFactory from "./SafeSingletonFactory";
+import DeterministicDeployer from "./DeterministicDeployer";
 import receiptOf from "./receiptOf";
 import makeDevFaster from "./makeDevFaster";
 import { getSigners } from "./getSigners";
@@ -49,13 +49,13 @@ export async function setupTests() {
 
   const entryPointAddress = entryPoints[0];
 
-  const ssf = await SafeSingletonFactory.init(admin);
+  const deployer = await DeterministicDeployer.init(admin);
 
-  const safeProxyFactory = await ssf.connectOrDeploy(
+  const safeProxyFactory = await deployer.connectOrDeploy(
     SafeProxyFactory__factory,
     [],
   );
-  const safeSingleton = await ssf.connectOrDeploy(Safe__factory, []);
+  const safeSingleton = await deployer.connectOrDeploy(Safe__factory, []);
 
   return {
     bundlerProvider,
@@ -64,7 +64,7 @@ export async function setupTests() {
     owner,
     otherAccount,
     entryPointAddress,
-    ssf,
+    deployer: deployer,
     safeProxyFactory,
     safeSingleton,
   };


### PR DESCRIPTION
## What is this PR doing?

Updates `SafeBlsPlugin` to use aggregation via eth-infinitism's `BLSSignatureAggregator` example.

Supporting changes:
- Switch to [arachnid's deterministic deployer](https://github.com/Arachnid/deterministic-deployment-proxy) for non-safe contracts for consistency with eth-infinitism and the broader ecosystem[^1][^2]
- Add support for linked libraries to deterministic deployer
- Patch the bundler to add partial aggregation support

## How can these changes be manually tested?

Run the tests per instructions ([allowing the webauthn test to fail](https://github.com/getwax/wax/issues/191)).

## Does this PR resolve or contribute to any issues?

Contributes to #190.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)

[^1]: [Arachnid's deployer](https://etherscan.io/address/0x4e59b44847b379578588920ca78fbf26c0b4956c) is >10x more popular than [safe's deployer](https://etherscan.io/address/0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7)
[^2]: Safe originally forked Arachnid's deployer so that they could use a couple of chains that were incompatible at the time. However, those chains have since added the necessary support for legacy transactions, so this foundational reason for Safe's deployer, which requires ongoing cooperation from a specific third party, no longer applies.
