### PR TITLE
Relayer initial work follow up

### DIFF
--- a/account-integrations/zkp/relayer/src/index.ts
+++ b/account-integrations/zkp/relayer/src/index.ts
@@ -54,8 +54,7 @@ const main = async () => {
     const emailTable = new EmailTable(db);
     const ethereumService = new EthereumService(
         ethPublicClient,
-        ethWalletClient,
-        emailTable
+        ethWalletClient
     );
     const emailService = new EmailService(
         imapClient,

--- a/account-integrations/zkp/relayer/src/index.ts
+++ b/account-integrations/zkp/relayer/src/index.ts
@@ -25,7 +25,7 @@ const main = async () => {
     const transporter = nodemailer.createTransport(config.smtpClient);
     transporter.verify((error) => {
         if (error) {
-            console.log(
+            console.error(
                 "An error occured verifying the SMTP configuration:",
                 error
             );
@@ -82,6 +82,6 @@ const main = async () => {
 };
 
 main().catch((error) => {
-    console.log("Error occured running relayer", error);
+    console.error("Error occured running relayer", error);
     process.exit(1);
 });

--- a/account-integrations/zkp/relayer/src/lib/imapClient.ts
+++ b/account-integrations/zkp/relayer/src/lib/imapClient.ts
@@ -8,7 +8,7 @@ type EmailResponse = {
 };
 
 class ImapClient {
-    public imapClient: ImapFlow;
+    private imapClient: ImapFlow;
 
     constructor(imapClientConfig: ImapFlowOptions) {
         this.imapClient = new ImapFlow(imapClientConfig);

--- a/account-integrations/zkp/relayer/src/lib/smtpClient.ts
+++ b/account-integrations/zkp/relayer/src/lib/smtpClient.ts
@@ -1,6 +1,13 @@
 import { Transporter } from "nodemailer";
 import { InitiateRecoveryResult } from "../services/ethereumService";
 
+type Message = {
+    from: string;
+    to: string;
+    subject: string;
+    text: string;
+};
+
 export default class SmtpClient {
     constructor(
         private transporter: Transporter,
@@ -11,27 +18,135 @@ export default class SmtpClient {
         to: string,
         initiateRecoveryResult: InitiateRecoveryResult
     ) {
-        let subject: string;
-        let text: string;
-        if (initiateRecoveryResult.success) {
-            subject = "Recovery initiated";
-            text = "Recovery was initiated successfully";
+        let message: Message;
+        if ("revertReason" in initiateRecoveryResult) {
+            message = this.generateFailureEmail(
+                to,
+                initiateRecoveryResult.newOwner,
+                initiateRecoveryResult.recoveryPlugin,
+                initiateRecoveryResult.safeAddress,
+                initiateRecoveryResult.revertReason
+            );
         } else {
-            subject = "Failed to initiate recovery";
-            text = "Failed to initiate recovery";
+            message = this.generateSuccessEmail(
+                to,
+                initiateRecoveryResult.newOwner,
+                initiateRecoveryResult.recoveryPlugin,
+                initiateRecoveryResult.safeAddress,
+                initiateRecoveryResult.executeAfter,
+                initiateRecoveryResult.blockTimestamp
+            );
         }
-
-        const message = {
-            from: this.relayerEmail,
-            to,
-            subject,
-            text,
-        };
 
         try {
             await this.transporter.sendMail(message);
         } catch (error) {
             console.error("Failed to send confirmation email.", error);
         }
+    }
+
+    private generateSuccessEmail(
+        to: string,
+        newOwner: string,
+        pluginAddress: string,
+        safeAddress: string,
+        executeAfter: bigint,
+        blockTimestamp: bigint
+    ): Message {
+        const executeAfterDate = new Date(Number(executeAfter) * 1000);
+        const executeAfterUtcDate = executeAfterDate.toUTCString();
+        const delay = this.formatDelay(executeAfter, blockTimestamp);
+
+        const subject = "Recovery initiated";
+        const text =
+            `Recovery was initiated successfully. A new owner has been ` +
+            `set to "${newOwner}" for the plugin "${pluginAddress}", on Safe ` +
+            `"${safeAddress}". This is a pending request so recovery can only ` +
+            `be executed after a pre-determined delay. There is a delay of ${delay}` +
+            ` - you can complete recovery after ${executeAfterUtcDate}.`;
+
+        return {
+            from: this.relayerEmail,
+            to,
+            subject,
+            text,
+        };
+    }
+
+    private generateFailureEmail(
+        to: string,
+        newOwner: string,
+        pluginAddress: string,
+        safeAddress: string,
+        revertReason: string
+    ): Message {
+        const formattedRevertReason = this.formatRevertReason(revertReason);
+        const subject = "Failed to initiate recovery";
+        const text =
+            `Failed to initiate recovery. The owner on plugin "${pluginAddress}" ` +
+            `could not be rotated to new owner "${newOwner}", on Safe ` +
+            `"${safeAddress}". ${formattedRevertReason}`;
+
+        return {
+            from: this.relayerEmail,
+            to,
+            subject,
+            text,
+        };
+    }
+
+    private formatRevertReason(revertReason: string): string {
+        const errorStringPrefix = "The recovery attempt failed because ";
+
+        let result: string;
+        switch (revertReason) {
+            case "RECOVERY_NOT_CONFIGURED":
+                result =
+                    "recovery has not been configured. The owner must configure recovery first before attempting to recover.";
+                break;
+            case "RECOVERY_ALREADY_INITIATED":
+                result =
+                    "recovery has already been initiated. Wait for the recovery delay to elapse or cancel the recovery request.";
+                break;
+            case "INVALID_DKIM_KEY_HASH":
+                result =
+                    "the DKIM public key hash is invalid. You may need to update the hash or update the DKIM registry the account is querying.";
+                break;
+            case "INVALID_PROOF":
+                result = "the proof is invalid.";
+                break;
+            default:
+                result = "an unknown error as occured.";
+        }
+
+        return errorStringPrefix + result;
+    }
+
+    private formatDelay(executeAfter: bigint, blockTimestamp: bigint) {
+        const delayInSeconds = Number(executeAfter) - Number(blockTimestamp);
+        const delayInMinutes = Math.floor(delayInSeconds / 60);
+        const delayInHours = Math.floor(delayInSeconds / 60 / 60);
+        const delayInDays = Math.floor(delayInSeconds / 60 / 60 / 24);
+
+        const oneMinuteInSeconds = 60;
+        const oneHourInSeconds = 3600;
+        const oneDayInSeconds = 86400;
+
+        if (delayInSeconds < oneMinuteInSeconds) {
+            return `${delayInSeconds} second(s)`;
+        }
+
+        const remainingSeconds = delayInSeconds % 60;
+        if (delayInSeconds < oneHourInSeconds) {
+            return `${delayInMinutes} minute(s), and ${remainingSeconds} second(s)`;
+        }
+
+        const remainingMinutes = delayInMinutes % 60;
+        if (delayInSeconds < oneDayInSeconds) {
+            return `${delayInHours} hour(s), ${remainingMinutes} minute(s), and ${remainingSeconds} second(s)`;
+        }
+
+        const remainingHours = delayInHours % 24;
+        return `${delayInDays} day(s), ${remainingHours} hour(s), ${remainingMinutes} minute(s), and ${remainingSeconds} second(s)`;
     }
 }

--- a/account-integrations/zkp/relayer/src/lib/smtpClient.ts
+++ b/account-integrations/zkp/relayer/src/lib/smtpClient.ts
@@ -3,8 +3,8 @@ import { InitiateRecoveryResult } from "../services/ethereumService";
 
 export default class SmtpClient {
     constructor(
-        public transporter: Transporter,
-        public relayerEmail: string
+        private transporter: Transporter,
+        private relayerEmail: string
     ) {}
 
     public async sendConfirmateEmail(

--- a/account-integrations/zkp/relayer/src/lib/smtpClient.ts
+++ b/account-integrations/zkp/relayer/src/lib/smtpClient.ts
@@ -7,7 +7,7 @@ export default class SmtpClient {
         private relayerEmail: string
     ) {}
 
-    public async sendConfirmateEmail(
+    public async sendConfirmationEmail(
         to: string,
         initiateRecoveryResult: InitiateRecoveryResult
     ) {

--- a/account-integrations/zkp/relayer/src/services/emailService.ts
+++ b/account-integrations/zkp/relayer/src/services/emailService.ts
@@ -9,12 +9,12 @@ export default class EmailService {
     private running = false;
 
     constructor(
-        public imapClient: ImapClient,
-        public smtpClient: SmtpClient,
-        public ethereumService: EthereumService,
-        public emailTable: EmailTable,
-        public pollingInterval: number,
-        public eventEmitter: EventEmitter
+        private imapClient: ImapClient,
+        private smtpClient: SmtpClient,
+        private ethereumService: EthereumService,
+        private emailTable: EmailTable,
+        private pollingInterval: number,
+        private eventEmitter: EventEmitter
     ) {
         this.eventEmitter.on("email(s) saved", () => this.processEmails());
     }

--- a/account-integrations/zkp/relayer/src/services/emailService.ts
+++ b/account-integrations/zkp/relayer/src/services/emailService.ts
@@ -150,7 +150,7 @@ export default class EmailService {
                 });
             }
 
-            console.log(
+            console.error(
                 `Could not initiate recovery. ${initiateRecoveryResult.message}`
             );
             return initiateRecoveryResult;
@@ -161,6 +161,6 @@ export default class EmailService {
         to: string,
         initiateRecoveryResult: InitiateRecoveryResult
     ) {
-        await this.smtpClient.sendConfirmateEmail(to, initiateRecoveryResult);
+        await this.smtpClient.sendConfirmationEmail(to, initiateRecoveryResult);
     }
 }

--- a/account-integrations/zkp/relayer/src/services/emailService.ts
+++ b/account-integrations/zkp/relayer/src/services/emailService.ts
@@ -6,6 +6,8 @@ import EmailTable, { Email, EmailStatus } from "../tables/emailTable";
 import EthereumService, { InitiateRecoveryResult } from "./ethereumService";
 
 export default class EmailService {
+    private running = false;
+
     constructor(
         public imapClient: ImapClient,
         public smtpClient: SmtpClient,
@@ -18,18 +20,19 @@ export default class EmailService {
     }
 
     async start() {
+        this.running = true;
         await this.pollEmails();
     }
 
     async stop() {
+        this.running = false;
         await this.imapClient.stop();
     }
 
     public async pollEmails(): Promise<void> {
         await this.imapClient.start();
 
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        while (this.running) {
             const emails = await this.imapClient.fetchEmails();
             console.log(`Received ${emails.length} emails`);
 

--- a/account-integrations/zkp/relayer/src/services/ethereumService.ts
+++ b/account-integrations/zkp/relayer/src/services/ethereumService.ts
@@ -1,14 +1,34 @@
-import { Address, PublicClient, WalletClient } from "viem";
+import {
+    Address,
+    TransactionReceipt,
+    PublicClient,
+    WalletClient,
+    decodeEventLog,
+} from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { hardhat } from "viem/chains";
 import pluginArtifact from "../config/SafeZkEmailRecoveryPlugin.json";
 import config from "../config/config";
 import parseViemError from "../utils/parseViemError";
 
-export type InitiateRecoveryResult = {
-    success: boolean;
-    message: string;
+type InitiateRecoverySuccess = {
+    safeAddress: Address;
+    newOwner: Address;
+    recoveryPlugin: Address;
+    executeAfter: bigint;
+    blockTimestamp: bigint;
 };
+
+type InitiateRecoveryFailure = {
+    safeAddress: Address;
+    newOwner: Address;
+    recoveryPlugin: Address;
+    revertReason: string;
+};
+
+export type InitiateRecoveryResult =
+    | InitiateRecoverySuccess
+    | InitiateRecoveryFailure;
 
 export default class EthereumService {
     constructor(
@@ -16,7 +36,7 @@ export default class EthereumService {
         private walletClient: WalletClient
     ) {}
 
-    async initiateRecovery(
+    public async initiateRecovery(
         safeProxyAddress: Address,
         newOwnerAddress: Address,
         recoveryPluginAddress: Address,
@@ -33,7 +53,8 @@ export default class EthereumService {
             address: account.address,
         });
 
-        // TODO: (merge-ok) fix typing
+        // TODO: (merge-ok) fix typing - https://github.com/getwax/wax/issues/205
+        let receipt: TransactionReceipt;
         try {
             const { request } = await this.publicClient.simulateContract({
                 address: recoveryPluginAddress,
@@ -46,19 +67,44 @@ export default class EthereumService {
             });
 
             const txHash = await this.walletClient.writeContract(request);
-            await this.publicClient.getTransactionReceipt({ hash: txHash });
+            receipt = await this.publicClient.getTransactionReceipt({
+                hash: txHash,
+            });
         } catch (error) {
             const parsedError = parseViemError(error);
 
             return {
-                success: false,
-                message: parsedError,
+                safeAddress: safeProxyAddress,
+                newOwner: newOwnerAddress,
+                recoveryPlugin: recoveryPluginAddress,
+                revertReason: parsedError,
             };
         }
 
+        const log = decodeEventLog({
+            abi: pluginArtifact.abi,
+            data: receipt.logs[0].data,
+            topics: receipt.logs[0].topics,
+        });
+
+        // TODO: (merge-ok) fix typing - https://github.com/getwax/wax/issues/205
+        // viem docs suggest type should be inferred so shouldn't need
+        // to do this - https://viem.sh/docs/contract/decodeEventLog#return-value.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const args = log.args as any;
+        const executeAfter = args.executeAfter as bigint;
+
+        const block = await this.publicClient.getBlock({
+            blockHash: receipt.blockHash,
+        });
+        const blockTimestamp = block.timestamp;
+
         return {
-            success: true,
-            message: "Recovery has been initiated",
+            safeAddress: safeProxyAddress,
+            newOwner: newOwnerAddress,
+            recoveryPlugin: recoveryPluginAddress,
+            executeAfter,
+            blockTimestamp,
         };
     }
 }

--- a/account-integrations/zkp/relayer/src/services/ethereumService.ts
+++ b/account-integrations/zkp/relayer/src/services/ethereumService.ts
@@ -1,7 +1,6 @@
 import { Address, PublicClient, WalletClient } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { hardhat } from "viem/chains";
-import EmailTable from "../tables/emailTable";
 import pluginArtifact from "../config/SafeZkEmailRecoveryPlugin.json";
 import config from "../config/config";
 import parseViemError from "../utils/parseViemError";
@@ -13,9 +12,8 @@ export type InitiateRecoveryResult = {
 
 export default class EthereumService {
     constructor(
-        public publicClient: PublicClient,
-        public walletClient: WalletClient,
-        public emailTable: EmailTable
+        private publicClient: PublicClient,
+        private walletClient: WalletClient
     ) {}
 
     async initiateRecovery(

--- a/account-integrations/zkp/relayer/src/tables/emailTable.ts
+++ b/account-integrations/zkp/relayer/src/tables/emailTable.ts
@@ -69,7 +69,7 @@ export default class EmailTable {
         createTableStatement.run();
     }
 
-    selectAll(): Array<Email> {
+    public selectAll(): Array<Email> {
         const selectAllStatement =
             this.database.prepare(`SELECT * FROM emails`);
         const rowList = selectAllStatement.all();
@@ -77,7 +77,7 @@ export default class EmailTable {
         return rowList.filter(isEmailRow).map(mapEmailRowToEmail);
     }
 
-    findEligible(): Array<Email> {
+    public findEligible(): Array<Email> {
         const selectEligibleStatement = this.database.prepare(`
             SELECT * FROM emails
                 WHERE
@@ -89,7 +89,7 @@ export default class EmailTable {
         return rowList.filter(isEmailRow).map(mapEmailRowToEmail);
     }
 
-    insert(email: InsertEmail) {
+    public insert(email: InsertEmail) {
         const insertStatement = this.database.prepare(
             `INSERT INTO emails (status, subject, sender) VALUES ($status, $subject, $sender)`
         );
@@ -100,7 +100,7 @@ export default class EmailTable {
         });
     }
 
-    update(email: Email) {
+    public update(email: Email) {
         const emailRow = mapEmailToEmailRow(email);
 
         const updateStatement = this.database.prepare(`

--- a/account-integrations/zkp/relayer/src/tables/emailTable.ts
+++ b/account-integrations/zkp/relayer/src/tables/emailTable.ts
@@ -57,7 +57,7 @@ const mapEmailToEmailRow = (row: Email): EmailRow => {
 };
 
 export default class EmailTable {
-    constructor(public database: Database) {
+    constructor(private database: Database) {
         const createTableStatement = this.database.prepare(`
             CREATE TABLE IF NOT EXISTS emails (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## What is this PR doing?
Follow ups from comments on #200 & #201
- Adds `running` flag to `emailService.ts` `pollEmails()` loop instead of doing `while(true)`
- Returns more helpful information in confirmation emails
  - Return some helpful info for this from ethereum service
  - Adds `generateFailureEmail` and `generateSuccessEmail` in smtp client to generate emails for respective scenarios
  - Adds helper functions in smtp client to format certain information in confirmation emails: `formatRevertReason` & `formatDelay`
- Other minor changes:
  - typos
  - use console.error
  - Update `InitiateRecoveryResult` with more info and make it a union type
  - better encapsulate classes

### Success email
![Screenshot 2024-02-06 at 17 30 51](https://github.com/getwax/wax/assets/54913924/6aa8bf6b-a89c-4f98-bc3b-a7122ee5409c)

### Failure email
![Screenshot 2024-02-06 at 13 21 36](https://github.com/getwax/wax/assets/54913924/30717d1b-4347-4c4d-b62f-61e0068c72fd)

## How can these changes be manually tested?
n/a

## Does this PR resolve or contribute to any issues?
Contributes to #173 

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
