### PR TITLE
Update EmailAccountRecoveryRouter and SafeZkEmailRecoveryPlugin contracts.

### DIFF
--- a/packages/plugins/src/safe/EmailAccountRecoveryRouter.sol
+++ b/packages/plugins/src/safe/EmailAccountRecoveryRouter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {EmailAuthMsg} from "ether-email-auth/packages/contracts/src/EmailAuth.sol";
+// import "forge-std/console.sol";
 
 interface IEmailAccountRecovery {
     function verifier() external view returns (address);

--- a/packages/plugins/src/safe/EmailAccountRecoveryRouter.sol
+++ b/packages/plugins/src/safe/EmailAccountRecoveryRouter.sol
@@ -4,6 +4,34 @@ pragma solidity ^0.8.0;
 import {EmailAuthMsg} from "ether-email-auth/packages/contracts/src/EmailAuth.sol";
 
 interface IEmailAccountRecovery {
+    function verifier() external view returns (address);
+
+    function dkim() external view returns (address);
+
+    function emailAuthImplementation() external view returns (address);
+
+    function acceptanceSubjectTemplates()
+        external
+        view
+        returns (string[][] memory);
+
+    function recoverySubjectTemplates()
+        external
+        view
+        returns (string[][] memory);
+
+    function computeEmailAuthAddress(
+        bytes32 accountSalt
+    ) external view returns (address);
+
+    function computeAcceptanceTemplateId(
+        uint templateIdx
+    ) external view returns (uint);
+
+    function computeRecoveryTemplateId(
+        uint templateIdx
+    ) external view returns (uint);
+
     function handleAcceptance(
         EmailAuthMsg memory emailAuthMsg,
         uint templateIdx
@@ -23,6 +51,64 @@ contract EmailAccountRecoveryRouter {
 
     constructor(address _emailAccountRecoveryImpl) {
         emailAccountRecoveryImpl = _emailAccountRecoveryImpl;
+    }
+
+    function verifier() external view returns (address) {
+        return IEmailAccountRecovery(emailAccountRecoveryImpl).verifier();
+    }
+
+    function dkim() external view returns (address) {
+        return IEmailAccountRecovery(emailAccountRecoveryImpl).dkim();
+    }
+
+    function emailAuthImplementation() external view returns (address) {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .emailAuthImplementation();
+    }
+
+    function acceptanceSubjectTemplates()
+        external
+        view
+        returns (string[][] memory)
+    {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .acceptanceSubjectTemplates();
+    }
+
+    function recoverySubjectTemplates()
+        external
+        view
+        returns (string[][] memory)
+    {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .recoverySubjectTemplates();
+    }
+
+    function computeEmailAuthAddress(
+        bytes32 accountSalt
+    ) external view returns (address) {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .computeEmailAuthAddress(accountSalt);
+    }
+
+    function computeAcceptanceTemplateId(
+        uint templateIdx
+    ) external view returns (uint) {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .computeAcceptanceTemplateId(templateIdx);
+    }
+
+    function computeRecoveryTemplateId(
+        uint templateIdx
+    ) external view returns (uint) {
+        return
+            IEmailAccountRecovery(emailAccountRecoveryImpl)
+                .computeRecoveryTemplateId(templateIdx);
     }
 
     function handleAcceptance(

--- a/packages/plugins/src/safe/SafeZkEmailRecoveryPlugin.sol
+++ b/packages/plugins/src/safe/SafeZkEmailRecoveryPlugin.sol
@@ -10,7 +10,6 @@ import {EmailAccountRecovery} from "ether-email-auth/packages/contracts/src/Emai
 //////////////////////////////////////////////////////////////////////////*/
 
 struct RecoveryRequest {
-    address guardian;
     uint256 executeAfter;
     address ownerToSwap;
     address pendingNewOwner;
@@ -153,6 +152,10 @@ contract SafeZkEmailRecoveryPlugin is EmailAccountRecovery {
             guardianRequests[guardian].safe != address(0),
             "guardian not requested"
         );
+        require(
+            !guardianRequests[guardian].accepted,
+            "guardian has already accepted"
+        );
         require(templateIdx == 0, "invalid template index");
         require(subjectParams.length == 1, "invalid subject params");
 
@@ -268,6 +271,11 @@ contract SafeZkEmailRecoveryPlugin is EmailAccountRecovery {
         bool moduleEnabled = ISafe(safe).isModuleEnabled(address(this));
         if (!moduleEnabled) revert MODULE_NOT_ENABLED();
 
+        require(
+            guardianRequests[guardian].safe == address(0),
+            "guardian already requested"
+        );
+
         bool isOwner = ISafe(safe).isOwner(owner);
         if (!isOwner) revert INVALID_OWNER(owner);
 
@@ -300,7 +308,7 @@ contract SafeZkEmailRecoveryPlugin is EmailAccountRecovery {
         }
 
         recoveryRequests[safe] = RecoveryRequest({
-            guardian: guardian,
+            // guardian: guardian,
             executeAfter: 0,
             ownerToSwap: owner,
             pendingNewOwner: address(0),

--- a/packages/plugins/src/safe/SafeZkEmailRecoveryPlugin.sol
+++ b/packages/plugins/src/safe/SafeZkEmailRecoveryPlugin.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {ISafe} from "./utils/Safe4337Base.sol";
 import {EmailAccountRecoveryRouter} from "./EmailAccountRecoveryRouter.sol";
 import {EmailAccountRecovery} from "ether-email-auth/packages/contracts/src/EmailAccountRecovery.sol";
-
+// import "forge-std/console.sol";
 /*//////////////////////////////////////////////////////////////////////////
     THIS CONTRACT IS STILL IN ACTIVE DEVELOPMENT. NOT FOR PRODUCTION USE        
 //////////////////////////////////////////////////////////////////////////*/
@@ -158,7 +158,7 @@ contract SafeZkEmailRecoveryPlugin is EmailAccountRecovery {
 
         address safeInEmail = abi.decode(subjectParams[0], (address));
         address safeForRouter = recoveryRouterToSafeInfo[msg.sender].safe;
-        require(safeForRouter != safeInEmail, "invalid account for router");
+        require(safeForRouter == safeInEmail, "invalid account for router");
         require(
             guardianRequests[guardian].safe == safeInEmail,
             "invalid account in email"
@@ -190,7 +190,7 @@ contract SafeZkEmailRecoveryPlugin is EmailAccountRecovery {
 
         address safeInEmail = abi.decode(subjectParams[1], (address));
         address safeForRouter = recoveryRouterToSafeInfo[msg.sender].safe;
-        require(safeForRouter != safeInEmail, "invalid account for router");
+        require(safeForRouter == safeInEmail, "invalid account for router");
         require(
             guardianRequests[guardian].safe == safeInEmail,
             "invalid account in email"

--- a/packages/plugins/test/integration/safe/SafeZkEmailRecoveryPluginIntegration.t.sol
+++ b/packages/plugins/test/integration/safe/SafeZkEmailRecoveryPluginIntegration.t.sol
@@ -33,7 +33,7 @@ contract SafeZkEmailRecoveryPlugin_Integration_Test is TestHelper {
     address public owner;
 
     // ZK email contracts
-    EmailAuth emailAuth;
+    // EmailAuth emailAuth;
     ECDSAOwnedDKIMRegistry ecdsaOwnedDkimRegistry;
     MockGroth16Verifier verifier;
     bytes32 accountSalt;
@@ -78,9 +78,9 @@ contract SafeZkEmailRecoveryPlugin_Integration_Test is TestHelper {
                 accountSalt
             )
         );
-        emailAuth = EmailAuth(payable(address(emailAuthProxy)));
-        emailAuth.updateVerifier(address(verifier));
-        emailAuth.updateDKIMRegistry(address(ecdsaOwnedDkimRegistry));
+        // emailAuth = EmailAuth(payable(address(emailAuthProxy)));
+        // emailAuth.updateVerifier(address(verifier));
+        // emailAuth.updateDKIMRegistry(address(ecdsaOwnedDkimRegistry));
         vm.stopPrank();
 
         safeZkEmailRecoveryPlugin = new SafeZkEmailRecoveryPlugin(
@@ -159,7 +159,7 @@ contract SafeZkEmailRecoveryPlugin_Integration_Test is TestHelper {
 
         // Handle acceptance
         bytes[] memory subjectParamsForAcceptance = new bytes[](1);
-        subjectParamsForAcceptance[0] = abi.encode(safeAddress); // TODO: might need to be entry contract
+        subjectParamsForAcceptance[0] = abi.encode(safeAddress);
         EmailAuthMsg memory emailAuthMsg = EmailAuthMsg({
             templateId: safeZkEmailRecoveryPlugin.computeAcceptanceTemplateId(
                 templateIdx
@@ -168,7 +168,6 @@ contract SafeZkEmailRecoveryPlugin_Integration_Test is TestHelper {
             skipedSubjectPrefix: 0,
             proof: emailProof
         });
-
         IEmailAccountRecovery(emailAccountRecoveryRouterAddress)
             .handleAcceptance(emailAuthMsg, templateIdx);
 

--- a/packages/plugins/test/unit/safe/SafeZkEmailRecoveryPlugin.t.sol
+++ b/packages/plugins/test/unit/safe/SafeZkEmailRecoveryPlugin.t.sol
@@ -58,7 +58,7 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
     string dkimPublicKey;
 
     // ZK email contracts
-    EmailAuth emailAuth;
+    // EmailAuth emailAuth;
     ECDSAOwnedDKIMRegistry ecdsaOwnedDkimRegistry;
     Verifier verifier;
     bytes32 accountSalt;
@@ -95,16 +95,16 @@ contract SafeZkEmailRecoveryPluginTest is TestHelper {
         accountSalt = 0x2c3abbf3d1171bfefee99c13bf9c47f1e8447576afd89096652a34f27b297971;
 
         EmailAuth emailAuthImpl = new EmailAuth();
-        ERC1967Proxy emailAuthProxy = new ERC1967Proxy(
-            address(emailAuthImpl),
-            abi.encodeWithSelector(
-                emailAuthImpl.initialize.selector,
-                accountSalt
-            )
-        );
-        emailAuth = EmailAuth(payable(address(emailAuthProxy)));
-        emailAuth.updateVerifier(address(verifier));
-        emailAuth.updateDKIMRegistry(address(ecdsaOwnedDkimRegistry));
+        // ERC1967Proxy emailAuthProxy = new ERC1967Proxy(
+        //     address(emailAuthImpl),
+        //     abi.encodeWithSelector(
+        //         emailAuthImpl.initialize.selector,
+        //         accountSalt
+        //     )
+        // );
+        // emailAuth = EmailAuth(payable(address(emailAuthProxy)));
+        // emailAuth.updateVerifier(address(verifier));
+        // emailAuth.updateDKIMRegistry(address(ecdsaOwnedDkimRegistry));
         vm.stopPrank();
 
         safeZkEmailRecoveryPlugin = new SafeZkEmailRecoveryPluginHarness(


### PR DESCRIPTION
## What is this PR doing?
I updated the EmailAccountRecoveryRouter and SafeZkEmailRecoveryPlugin contracts to implement all of the external functions of `EmailAccountRecovery` in EmailAccountRecoveryRouter. Besides, I added some requirements to SafeZkEmailRecoveryPlugin for better security.

## How can these changes be manually tested?
I confirmed that the test of `forge test --match-contract SafeZkEmailRecoveryPlugin_Integration_Test -vv` passed.
